### PR TITLE
Improve privileged password visibility and user creation feedback

### DIFF
--- a/ERP 2 evaluacion/PrincipalForm.cs
+++ b/ERP 2 evaluacion/PrincipalForm.cs
@@ -13,6 +13,7 @@ namespace ERP_2_evaluacion
     {
         private readonly int _idUsuario;
         private readonly string _nombreUsuario;
+        private readonly bool _usuarioPrivilegiado;
 
         private readonly TreeView _arbolPantallas = new() { Dock = DockStyle.Fill };
         private readonly Label _lblBienvenida = new() { AutoSize = true };
@@ -40,6 +41,17 @@ namespace ERP_2_evaluacion
         {
             _idUsuario = idUsuario;
             _nombreUsuario = nombreUsuario;
+
+            try
+            {
+                _usuarioPrivilegiado = SeguridadUtil.EsUsuarioPrivilegiadoPorId(idUsuario);
+            }
+            catch (Exception ex)
+            {
+                _usuarioPrivilegiado = false;
+                MessageBox.Show($"No se pudieron validar los privilegios del usuario: {ex.Message}",
+                    "Advertencia", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
 
             Text = "Principal";
             WindowState = FormWindowState.Maximized;
@@ -498,7 +510,7 @@ ORDER BY CASE WHEN p.IdPadre IS NULL THEN 0 ELSE 1 END,
         {
             Form? formulario = codigoPantalla switch
             {
-                "USUARIOS" => new UsuariosForm(),
+                "USUARIOS" => new UsuariosForm(_usuarioPrivilegiado),
                 "PERFILES" => new PerfilesForm(),
                 "ACCESOS" => new AccesosForm(),
                 _ => null

--- a/ERP 2 evaluacion/Program.cs
+++ b/ERP 2 evaluacion/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Forms;
 
 namespace ERP_2_evaluacion;
@@ -7,6 +8,21 @@ internal static class Program
     [STAThread]
     static void Main()
     {
+        Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+        Application.ThreadException += (_, args) =>
+        {
+            MessageBox.Show($"Ocurrió un error inesperado: {args.Exception.Message}",
+                "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        };
+        AppDomain.CurrentDomain.UnhandledException += (_, args) =>
+        {
+            if (args.ExceptionObject is Exception ex)
+            {
+                MessageBox.Show($"Ocurrió un error crítico: {ex.Message}",
+                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        };
+
         ApplicationConfiguration.Initialize();
         Application.Run(new LoginForm());
     }

--- a/ERP 2 evaluacion/SeguridadUtil.cs
+++ b/ERP 2 evaluacion/SeguridadUtil.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Data.SqlClient;
 
 namespace ERP_2_evaluacion;
 
@@ -9,6 +11,10 @@ public static class SeguridadUtil
     public const int LongitudMinimaPassword = 8;
     public const int LongitudMaximaPassword = 50;
     public const string ContrasenaPorDefecto = "Temporal123";
+
+    private static readonly string[] CodigosPerfilesPrivilegiados = { "SUPERADMIN", "ADMIN" };
+    private static readonly string CodigosPrivilegiadosSql = string.Join(", ",
+        CodigosPerfilesPrivilegiados.Select((_, index) => $"@codigoPriv{index}"));
 
     public static string GenerarPasswordTemporal(int largo = 12)
     {
@@ -33,5 +39,62 @@ public static class SeguridadUtil
         }
 
         return sb.ToString();
+    }
+
+    public static bool EsUsuarioPrivilegiadoPorId(int idUsuario)
+    {
+        return EjecutarConsultaPrivilegio(connection =>
+        {
+            var command = new SqlCommand($@"SELECT TOP 1 1
+FROM UsuarioPerfil up
+JOIN Perfil p ON p.IdPerfil = up.IdPerfil
+WHERE up.IdUsuario = @idUsuario
+  AND p.Codigo IN ({CodigosPrivilegiadosSql});", connection);
+            command.Parameters.AddWithValue("@idUsuario", idUsuario);
+            AgregarParametrosPrivilegio(command);
+            return command;
+        });
+    }
+
+    public static bool EsUsuarioPrivilegiadoPorIdentificador(string identificador)
+    {
+        if (string.IsNullOrWhiteSpace(identificador))
+        {
+            return false;
+        }
+
+        return EjecutarConsultaPrivilegio(connection =>
+        {
+            var command = new SqlCommand($@"SELECT TOP 1 1
+FROM Usuario u
+WHERE (u.NombreUsuario = @identificador OR u.Correo = @identificador)
+  AND EXISTS (
+        SELECT 1
+        FROM UsuarioPerfil up
+        JOIN Perfil p ON p.IdPerfil = up.IdPerfil
+        WHERE up.IdUsuario = u.IdUsuario
+          AND p.Codigo IN ({CodigosPrivilegiadosSql})
+    );", connection);
+            command.Parameters.AddWithValue("@identificador", identificador);
+            AgregarParametrosPrivilegio(command);
+            return command;
+        });
+    }
+
+    private static bool EjecutarConsultaPrivilegio(Func<SqlConnection, SqlCommand> comandoFactory)
+    {
+        using var connection = Db.GetConnection();
+        connection.Open();
+        using var command = comandoFactory(connection);
+        var resultado = command.ExecuteScalar();
+        return resultado != null && resultado != DBNull.Value;
+    }
+
+    private static void AgregarParametrosPrivilegio(SqlCommand command)
+    {
+        for (int i = 0; i < CodigosPerfilesPrivilegiados.Length; i++)
+        {
+            command.Parameters.AddWithValue($"@codigoPriv{i}", CodigosPerfilesPrivilegiados[i]);
+        }
     }
 }

--- a/ERP 2 evaluacion/SuperUsuarioForm.cs
+++ b/ERP 2 evaluacion/SuperUsuarioForm.cs
@@ -18,6 +18,7 @@ public class SuperUsuarioForm : Form
     private readonly TextBox _txtCorreo = new() { PlaceholderText = "Correo electrónico" };
     private readonly TextBox _txtClave = new() { UseSystemPasswordChar = true, PlaceholderText = "Contraseña", MaxLength = 50 };
     private readonly TextBox _txtConfirmacion = new() { UseSystemPasswordChar = true, PlaceholderText = "Confirmar contraseña", MaxLength = 50 };
+    private readonly CheckBox _chkMostrarClave = new() { Text = "Mostrar contraseñas" };
     private readonly Button _btnCrear = new() { Text = "Crear super usuario" };
     private readonly Button _btnCancelar = new() { Text = "Cancelar", DialogResult = DialogResult.Cancel };
     private readonly Label _lblMensaje = new() { AutoSize = true, ForeColor = UiTheme.DangerColor, Margin = new Padding(0, 8, 0, 0) };
@@ -50,10 +51,13 @@ public class SuperUsuarioForm : Form
         UiTheme.StyleTextInput(_txtCorreo);
         UiTheme.StyleTextInput(_txtClave);
         UiTheme.StyleTextInput(_txtConfirmacion);
+        UiTheme.StyleCheckBox(_chkMostrarClave);
         UiTheme.StylePrimaryButton(_btnCrear);
         UiTheme.StyleSecondaryButton(_btnCancelar);
 
         _btnCrear.Click += (_, _) => CrearSuperUsuario();
+        _chkMostrarClave.CheckedChanged += (_, _) => AlternarVisibilidadClaves();
+        AlternarVisibilidadClaves();
 
         var titulo = UiTheme.CreateTitleLabel("Super usuario");
         var subtitulo = new Label
@@ -103,7 +107,10 @@ public class SuperUsuarioForm : Form
         layout.Controls.Add(_txtConfirmacion, 0, 11);
 
         layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        layout.Controls.Add(_lblMensaje, 0, 12);
+        layout.Controls.Add(_chkMostrarClave, 0, 12);
+
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(_lblMensaje, 0, 13);
 
         var panelBotones = new FlowLayoutPanel
         {
@@ -117,7 +124,7 @@ public class SuperUsuarioForm : Form
         panelBotones.Controls.Add(_btnCrear);
         panelBotones.Controls.Add(_btnCancelar);
         layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        layout.Controls.Add(panelBotones, 0, 13);
+        layout.Controls.Add(panelBotones, 0, 14);
 
         var card = UiTheme.CreateCardPanel();
         card.AutoSize = true;
@@ -249,6 +256,13 @@ public class SuperUsuarioForm : Form
 
             MessageBox.Show($"No se pudo crear el super usuario: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
+    }
+
+    private void AlternarVisibilidadClaves()
+    {
+        var mostrar = _chkMostrarClave.Checked;
+        _txtClave.UseSystemPasswordChar = !mostrar;
+        _txtConfirmacion.UseSystemPasswordChar = !mostrar;
     }
 
     private static bool ExisteSuperUsuario(SqlConnection connection, SqlTransaction transaction)


### PR DESCRIPTION
## Summary
- add global exception handlers so unexpected errors surface as dialogs instead of terminating the app
- implement privilege-aware password visibility toggles and utility helpers for login and administration flows
- enhance the usuarios form with clearer full-name guidance and optional password reveal for privileged operators

## Testing
- `dotnet build "ERP 2 evaluacion/ERP 2 evaluacion.csproj"` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2de96c66c8332873afd2c873e683d