### PR TITLE
Seed super admin user and remove UI creation flow

### DIFF
--- a/Create.sql
+++ b/Create.sql
@@ -22,6 +22,10 @@ CREATE TABLE dbo.Usuario
 );
 GO
 
+ALTER TABLE dbo.Usuario
+ADD CONSTRAINT CK_Usuario_ClaveLength CHECK (LEN(Clave) >= 8);
+GO
+
 CREATE TABLE dbo.Perfil
 (
     IdPerfil INT IDENTITY(1,1) PRIMARY KEY,

--- a/ERP 2 evaluacion/LoginForm.cs
+++ b/ERP 2 evaluacion/LoginForm.cs
@@ -21,7 +21,6 @@ public class LoginForm : Form
     private readonly CheckBox _chkMostrarClave = new() { Text = "Mostrar contraseña" };
     private readonly Button _btnIngresar = new() { Text = "Ingresar" };
     private readonly Button _btnRegistrarse = new() { Text = "Crear cuenta" };
-    private readonly Button _btnSuperUsuario = new() { Text = "Crear super usuario" };
     private readonly Label _lblMensaje = new() { AutoSize = true, ForeColor = UiTheme.DangerColor, Margin = new Padding(0, 8, 0, 0) };
 
     private string? _ultimoUsuarioConsultado;
@@ -45,13 +44,9 @@ public class LoginForm : Form
         UiTheme.StyleCheckBox(_chkMostrarClave);
         UiTheme.StylePrimaryButton(_btnIngresar);
         UiTheme.StyleSecondaryButton(_btnRegistrarse);
-        UiTheme.StyleSecondaryButton(_btnSuperUsuario);
-        _btnSuperUsuario.Visible = false;
 
         _btnIngresar.Click += BtnIngresar_Click;
         _btnRegistrarse.Click += BtnRegistrarse_Click;
-        _btnSuperUsuario.Click += BtnSuperUsuario_Click;
-        Load += LoginForm_Load;
         _chkMostrarClave.CheckedChanged += (_, _) => AlternarVisibilidadClave();
         _txtUsuario.TextChanged += (_, _) => ReiniciarVerificacionPrivilegios();
 
@@ -93,7 +88,6 @@ public class LoginForm : Form
         };
         panelBotones.Controls.Add(_btnIngresar);
         panelBotones.Controls.Add(_btnRegistrarse);
-        panelBotones.Controls.Add(_btnSuperUsuario);
         layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         layout.Controls.Add(panelBotones, 0, 8);
 
@@ -122,19 +116,6 @@ public class LoginForm : Form
         root.Controls.Add(card, 1, 1);
 
         Controls.Add(root);
-    }
-
-    private void LoginForm_Load(object? sender, EventArgs e)
-    {
-        try
-        {
-            _btnSuperUsuario.Visible = !SuperUsuarioExiste();
-        }
-        catch (Exception ex)
-        {
-            _btnSuperUsuario.Visible = false;
-            MessageBox.Show($"No se pudo verificar el super usuario: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-        }
     }
 
     private void BtnIngresar_Click(object? sender, EventArgs e)
@@ -209,17 +190,6 @@ FROM Usuario WHERE NombreUsuario = @usuario OR Correo = @usuario", connection);
         }
     }
 
-    private void BtnSuperUsuario_Click(object? sender, EventArgs e)
-    {
-        using var super = new SuperUsuarioForm();
-        if (super.ShowDialog(this) == DialogResult.OK)
-        {
-            _btnSuperUsuario.Visible = false;
-            _lblMensaje.ForeColor = UiTheme.AccentColor;
-            _lblMensaje.Text = "Super usuario creado. Inicia sesión con esas credenciales.";
-        }
-    }
-
     private void AlternarVisibilidadClave()
     {
         if (!_chkMostrarClave.Checked)
@@ -286,13 +256,4 @@ FROM Usuario WHERE NombreUsuario = @usuario OR Correo = @usuario", connection);
         }
     }
 
-    private static bool SuperUsuarioExiste()
-    {
-        var resultado = Db.Scalar(@"SELECT TOP 1 1
-FROM UsuarioPerfil up
-JOIN Perfil p ON p.IdPerfil = up.IdPerfil
-WHERE p.Codigo = @codigo;", parametros => parametros.AddWithValue("@codigo", "SUPERADMIN"));
-
-        return resultado != null && resultado != DBNull.Value;
-    }
 }

--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@ Solución mínima de WinForms (.NET 8) y SQL Server para la primera etapa del ER
 ## Pasos de instalación
 1. Crear una base de datos vacía en SQL Server (por ejemplo `ERP2`).
 2. Ejecutar el script [`Create.sql`](Create.sql) sobre la base de datos para generar el esquema.
-3. Ejecutar el script [`Seed.sql`](Seed.sql) para cargar las pantallas base y el perfil `ADMIN`.
+3. Ejecutar el script [`Seed.sql`](Seed.sql) para cargar las pantallas base, los perfiles principales y el usuario super administrador por defecto.
 4. Abrir la solución `ERP 2 evaluacion.sln` en Visual Studio 2022 o posterior.
 5. Ajustar la cadena de conexión `DefaultConnection` en `App.config` si es necesario.
 6. Compilar y ejecutar la aplicación.
 
 ## Primer uso
 
-Al iniciar la aplicación por primera vez, utilice la opción **"Crear super usuario"** del formulario de inicio de sesión. Solo puede existir un super usuario y se creará con acceso total a todas las pantallas, pudiendo gestionar desde allí al resto de usuarios y perfiles.
+Después de ejecutar los scripts de base de datos, inicia sesión con el usuario super administrador preconfigurado:
 
-Después de crear al super usuario, podrá iniciar sesión con las credenciales definidas y continuar utilizando el menú para realizar el CRUD completo de usuarios, perfiles y accesos.
+| Usuario | Contraseña |
+|---------|------------|
+| `admin` | `admin123` |
+
+Ese usuario posee el perfil `SUPERADMIN`, con permisos completos sobre todas las pantallas. Desde su sesión puedes crear nuevos usuarios, perfiles y administrar los niveles de acceso del sistema.

--- a/Seed.sql
+++ b/Seed.sql
@@ -1,6 +1,9 @@
 SET NOCOUNT ON;
 GO
 
+DECLARE @Ahora DATETIME = GETDATE();
+
+-- Pantallas base requeridas por la aplicación
 IF NOT EXISTS (SELECT 1 FROM dbo.Pantalla WHERE Codigo = 'LOGIN')
 BEGIN
     INSERT INTO dbo.Pantalla (Codigo, NombrePantalla, Ruta, Orden, CreadoPor)
@@ -33,9 +36,83 @@ BEGIN
     VALUES ('ACCESOS', 'Accesos', 'AccesosForm', @IdPantallaPrincipal, 3, 'SEED');
 END;
 
+-- Perfiles básicos de la aplicación
+IF NOT EXISTS (SELECT 1 FROM dbo.Perfil WHERE Codigo = 'SUPERADMIN')
+BEGIN
+    INSERT INTO dbo.Perfil (NombrePerfil, Codigo, Descripcion, Activo)
+    VALUES ('Super Administrador', 'SUPERADMIN', 'Control total del sistema', 1);
+END;
+
 IF NOT EXISTS (SELECT 1 FROM dbo.Perfil WHERE Codigo = 'ADMIN')
 BEGIN
     INSERT INTO dbo.Perfil (NombrePerfil, Codigo, Descripcion, Activo)
-    VALUES ('ADMIN', 'ADMIN', 'Perfil administrador con gestión completa', 1);
+    VALUES ('Administrador', 'ADMIN', 'Administrador funcional con permisos ampliados', 1);
 END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Perfil WHERE Codigo = 'BASICO')
+BEGIN
+    INSERT INTO dbo.Perfil (NombrePerfil, Codigo, Descripcion, Activo)
+    VALUES ('Básico', 'BASICO', 'Perfil por defecto para nuevos usuarios', 1);
+END;
+
+DECLARE @IdPerfilSuper INT = (SELECT IdPerfil FROM dbo.Perfil WHERE Codigo = 'SUPERADMIN');
+
+-- Crear o actualizar el super usuario por defecto
+DECLARE @IdUsuarioAdmin INT;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Usuario WHERE NombreUsuario = 'admin')
+BEGIN
+    INSERT INTO dbo.Usuario (NombreUsuario, Correo, Clave, NombreCompleto, Activo, UltimoIngreso, FechaCreacion)
+    VALUES ('admin', 'admin@erp.local', 'admin123', 'Super Administrador del sistema', 1, NULL, CAST(@Ahora AS DATE));
+
+    SET @IdUsuarioAdmin = SCOPE_IDENTITY();
+END;
+ELSE
+BEGIN
+    SELECT @IdUsuarioAdmin = IdUsuario FROM dbo.Usuario WHERE NombreUsuario = 'admin';
+
+    UPDATE dbo.Usuario
+    SET Correo = CASE
+                     WHEN Correo = 'admin@erp.local' THEN Correo
+                     WHEN NOT EXISTS (SELECT 1 FROM dbo.Usuario WHERE Correo = 'admin@erp.local' AND IdUsuario <> @IdUsuarioAdmin)
+                         THEN 'admin@erp.local'
+                     ELSE Correo
+                 END,
+        Clave = 'admin123',
+        NombreCompleto = CASE WHEN NULLIF(LTRIM(RTRIM(NombreCompleto)), '') IS NULL THEN 'Super Administrador del sistema' ELSE NombreCompleto END,
+        Activo = 1
+    WHERE IdUsuario = @IdUsuarioAdmin;
+END;
+
+IF @IdUsuarioAdmin IS NULL
+BEGIN
+    SELECT @IdUsuarioAdmin = IdUsuario FROM dbo.Usuario WHERE NombreUsuario = 'admin';
+END;
+
+-- Asignar el perfil SUPERADMIN al usuario admin
+IF NOT EXISTS (SELECT 1 FROM dbo.UsuarioPerfil WHERE IdUsuario = @IdUsuarioAdmin AND IdPerfil = @IdPerfilSuper)
+BEGIN
+    INSERT INTO dbo.UsuarioPerfil (IdUsuario, IdPerfil, AsignadoPor)
+    VALUES (@IdUsuarioAdmin, @IdPerfilSuper, 'SEED');
+END;
+
+-- Otorgar permisos completos al perfil SUPERADMIN sobre todas las pantallas
+MERGE dbo.PerfilPantallaAcceso AS destino
+USING (
+    SELECT @IdPerfilSuper AS IdPerfil, IdPantalla
+    FROM dbo.Pantalla
+) AS origen
+ON destino.IdPerfil = origen.IdPerfil AND destino.IdPantalla = origen.IdPantalla
+WHEN MATCHED THEN
+    UPDATE SET PuedeVer = 1,
+               PuedeCrear = 1,
+               PuedeEditar = 1,
+               PuedeEliminar = 1,
+               PuedeExportar = 1,
+               Activo = 1,
+               FechaOtorgado = @Ahora,
+               OtorgadoPor = 'SEED'
+WHEN NOT MATCHED THEN
+    INSERT (IdPerfil, IdPantalla, PuedeVer, PuedeCrear, PuedeEditar, PuedeEliminar, PuedeExportar, Activo, FechaOtorgado, OtorgadoPor)
+    VALUES (origen.IdPerfil, origen.IdPantalla, 1, 1, 1, 1, 1, 1, @Ahora, 'SEED');
 GO


### PR DESCRIPTION
## Summary
- enforce the minimum password length at the database level for users
- seed the base profiles, default super administrator, and grant full permissions to that profile
- remove the UI entry point for creating a super user and update the documentation with the new login flow

## Testing
- Not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2e55af350833280e187a5c356db51