### PR TITLE
Add sales and inventory management modules

### DIFF
--- a/ERP 2 evaluacion/BodegasForm.cs
+++ b/ERP 2 evaluacion/BodegasForm.cs
@@ -1,0 +1,298 @@
+using Microsoft.Data.SqlClient;
+using System;
+using System.Data;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ERP_2_evaluacion;
+
+public class BodegasForm : Form
+{
+    private readonly DataGridView _grid = new()
+    {
+        Dock = DockStyle.Fill,
+        ReadOnly = true,
+        SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+        MultiSelect = false,
+        AutoGenerateColumns = false
+    };
+
+    private readonly TextBox _txtCodigo = new() { PlaceholderText = "Código" };
+    private readonly TextBox _txtNombre = new() { PlaceholderText = "Nombre" };
+    private readonly TextBox _txtUbicacion = new() { PlaceholderText = "Ubicación" };
+    private readonly TextBox _txtEncargado = new() { PlaceholderText = "Encargado" };
+    private readonly TextBox _txtDescripcion = new() { Multiline = true, Height = 80, PlaceholderText = "Descripción" };
+    private readonly CheckBox _chkActivo = new() { Text = "Activo", Checked = true };
+
+    private readonly Button _btnNuevo = new() { Text = "Nuevo" };
+    private readonly Button _btnGuardar = new() { Text = "Guardar" };
+    private readonly Button _btnActivar = new() { Text = "Activar" };
+    private readonly Button _btnDesactivar = new() { Text = "Desactivar" };
+
+    private readonly Label _lblMensaje = new() { AutoSize = true, ForeColor = UiTheme.DangerColor };
+
+    private int? _idSeleccionado;
+
+    public BodegasForm()
+    {
+        Text = "Bodegas";
+        StartPosition = FormStartPosition.CenterParent;
+        Size = new Size(1200, 780);
+        MinimumSize = new Size(1024, 680);
+
+        UiTheme.ApplyMinimalStyle(this);
+
+        ConfigurarGrid();
+        UiTheme.StyleDataGrid(_grid);
+
+        UiTheme.StyleTextInput(_txtCodigo);
+        UiTheme.StyleTextInput(_txtNombre);
+        UiTheme.StyleTextInput(_txtUbicacion);
+        UiTheme.StyleTextInput(_txtEncargado);
+        UiTheme.StyleTextInput(_txtDescripcion);
+        UiTheme.StyleCheckBox(_chkActivo);
+
+        UiTheme.StyleSecondaryButton(_btnNuevo);
+        UiTheme.StylePrimaryButton(_btnGuardar);
+        UiTheme.StyleSuccessButton(_btnActivar);
+        UiTheme.StyleDangerButton(_btnDesactivar);
+        _btnGuardar.Margin = new Padding(0);
+
+        var layout = CrearLayout();
+
+        var gridCard = UiTheme.CreateCardPanel();
+        gridCard.Padding = new Padding(32, 32, 32, 24);
+        gridCard.Controls.Add(_grid);
+
+        var split = new SplitContainer
+        {
+            Dock = DockStyle.Fill,
+            Orientation = Orientation.Horizontal,
+            BorderStyle = BorderStyle.None,
+            SplitterWidth = 12
+        };
+        split.Panel1.Controls.Add(gridCard);
+        split.Panel2.Controls.Add(layout);
+
+        Controls.Add(split);
+
+        Load += (_, _) =>
+        {
+            CargarBodegas();
+            ActualizarAccionesEstado(null);
+        };
+        _grid.SelectionChanged += (_, _) => CargarSeleccion();
+        _btnNuevo.Click += (_, _) => LimpiarFormulario();
+        _btnGuardar.Click += (_, _) => GuardarBodega();
+        _btnDesactivar.Click += (_, _) => CambiarEstadoBodega(false);
+        _btnActivar.Click += (_, _) => CambiarEstadoBodega(true);
+    }
+
+    private void ConfigurarGrid()
+    {
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Id", DataPropertyName = "IdBodega", Width = 60 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Código", DataPropertyName = "Codigo", Width = 120 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Nombre", DataPropertyName = "Nombre", AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Ubicación", DataPropertyName = "Ubicacion", AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Encargado", DataPropertyName = "Encargado", Width = 200 });
+        _grid.Columns.Add(new DataGridViewCheckBoxColumn { HeaderText = "Activo", DataPropertyName = "Activo", Width = 80 });
+    }
+
+    private Control CrearLayout()
+    {
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 2,
+            Padding = new Padding(0, 0, 0, 16)
+        };
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+
+        layout.Controls.Add(new Label { Text = "Código", AutoSize = true, ForeColor = UiTheme.MutedTextColor }, 0, 0);
+        layout.Controls.Add(new Label { Text = "Nombre", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 0, 0, 0) }, 1, 0);
+        layout.Controls.Add(_txtCodigo, 0, 1);
+        layout.Controls.Add(_txtNombre, 1, 1);
+
+        layout.Controls.Add(new Label { Text = "Ubicación", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(0, 12, 0, 0) }, 0, 2);
+        layout.Controls.Add(new Label { Text = "Encargado", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 12, 0, 0) }, 1, 2);
+        layout.Controls.Add(_txtUbicacion, 0, 3);
+        layout.Controls.Add(_txtEncargado, 1, 3);
+
+        layout.Controls.Add(new Label { Text = "Descripción", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(0, 12, 0, 0) }, 0, 4);
+        layout.SetColumnSpan(_txtDescripcion, 2);
+        layout.Controls.Add(_txtDescripcion, 0, 5);
+
+        layout.Controls.Add(_chkActivo, 0, 6);
+        layout.SetColumnSpan(_chkActivo, 2);
+        layout.Controls.Add(_lblMensaje, 0, 7);
+        layout.SetColumnSpan(_lblMensaje, 2);
+
+        var botones = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Bottom,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false,
+            Padding = new Padding(0, 24, 0, 0)
+        };
+        botones.Controls.AddRange(new Control[] { _btnGuardar, _btnNuevo, _btnActivar, _btnDesactivar });
+
+        var card = UiTheme.CreateCardPanel();
+        card.AutoScroll = true;
+        card.Padding = new Padding(32, 32, 32, 24);
+        card.Controls.Add(layout);
+        card.Controls.Add(botones);
+
+        return card;
+    }
+
+    private void CargarBodegas()
+    {
+        try
+        {
+            _grid.DataSource = Db.GetDataTable("SELECT IdBodega, Codigo, Nombre, Ubicacion, Encargado, Descripcion, Activo FROM Bodega ORDER BY Nombre");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar bodegas: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarSeleccion()
+    {
+        if (_grid.SelectedRows.Count == 0)
+        {
+            return;
+        }
+
+        if (_grid.SelectedRows[0].DataBoundItem is DataRowView fila)
+        {
+            _idSeleccionado = (int)fila["IdBodega"];
+            _txtCodigo.Text = Convert.ToString(fila["Codigo"]) ?? string.Empty;
+            _txtNombre.Text = Convert.ToString(fila["Nombre"]) ?? string.Empty;
+            _txtUbicacion.Text = Convert.ToString(fila["Ubicacion"]) ?? string.Empty;
+            _txtEncargado.Text = Convert.ToString(fila["Encargado"]) ?? string.Empty;
+            _txtDescripcion.Text = Convert.ToString(fila["Descripcion"]) ?? string.Empty;
+            var activo = fila.Row.Field<bool>("Activo");
+            _chkActivo.Checked = activo;
+            ActualizarAccionesEstado(activo);
+        }
+    }
+
+    private void LimpiarFormulario()
+    {
+        _idSeleccionado = null;
+        _txtCodigo.Text = string.Empty;
+        _txtNombre.Text = string.Empty;
+        _txtUbicacion.Text = string.Empty;
+        _txtEncargado.Text = string.Empty;
+        _txtDescripcion.Text = string.Empty;
+        _chkActivo.Checked = true;
+        _lblMensaje.Text = string.Empty;
+        _grid.ClearSelection();
+        ActualizarAccionesEstado(null);
+    }
+
+    private void ActualizarAccionesEstado(bool? activo)
+    {
+        var haySeleccion = _idSeleccionado != null;
+        _btnActivar.Enabled = haySeleccion && activo == false;
+        _btnDesactivar.Enabled = haySeleccion && activo != false;
+    }
+
+    private void GuardarBodega()
+    {
+        _lblMensaje.Text = string.Empty;
+        var codigo = _txtCodigo.Text.Trim();
+        var nombre = _txtNombre.Text.Trim();
+        var ubicacion = _txtUbicacion.Text.Trim();
+        var encargado = _txtEncargado.Text.Trim();
+        var descripcion = _txtDescripcion.Text.Trim();
+        var activo = _chkActivo.Checked;
+
+        if (codigo.Length == 0 || nombre.Length == 0)
+        {
+            _lblMensaje.Text = "Código y nombre son obligatorios";
+            return;
+        }
+
+        try
+        {
+            using var connection = Db.GetConnection();
+            connection.Open();
+
+            SqlCommand command;
+            if (_idSeleccionado == null)
+            {
+                command = new SqlCommand(@"INSERT INTO Bodega (Codigo, Nombre, Ubicacion, Encargado, Descripcion, Activo)
+VALUES (@codigo, @nombre, @ubicacion, @encargado, @descripcion, @activo);", connection);
+            }
+            else
+            {
+                command = new SqlCommand(@"UPDATE Bodega
+SET Codigo = @codigo,
+    Nombre = @nombre,
+    Ubicacion = @ubicacion,
+    Encargado = @encargado,
+    Descripcion = @descripcion,
+    Activo = @activo
+WHERE IdBodega = @id;", connection);
+                command.Parameters.AddWithValue("@id", _idSeleccionado.Value);
+            }
+
+            command.Parameters.AddWithValue("@codigo", codigo);
+            command.Parameters.AddWithValue("@nombre", nombre);
+            command.Parameters.AddWithValue("@ubicacion", string.IsNullOrWhiteSpace(ubicacion) ? DBNull.Value : ubicacion);
+            command.Parameters.AddWithValue("@encargado", string.IsNullOrWhiteSpace(encargado) ? DBNull.Value : encargado);
+            command.Parameters.AddWithValue("@descripcion", string.IsNullOrWhiteSpace(descripcion) ? DBNull.Value : descripcion);
+            command.Parameters.AddWithValue("@activo", activo);
+
+            command.ExecuteNonQuery();
+
+            MessageBox.Show("Bodega guardada correctamente", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            LimpiarFormulario();
+            CargarBodegas();
+        }
+        catch (SqlException ex) when (ex.Number is 2601 or 2627)
+        {
+            _lblMensaje.Text = "El código de la bodega ya existe";
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al guardar la bodega: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CambiarEstadoBodega(bool activar)
+    {
+        if (_idSeleccionado == null)
+        {
+            MessageBox.Show("Seleccione una bodega primero", "Atención", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var mensaje = activar ? "activar" : "desactivar";
+        if (MessageBox.Show($"¿Seguro que desea {mensaje} la bodega seleccionada?", "Confirmación", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+        {
+            return;
+        }
+
+        try
+        {
+            Db.Execute("UPDATE Bodega SET Activo = @activo WHERE IdBodega = @id", p =>
+            {
+                p.AddWithValue("@activo", activar);
+                p.AddWithValue("@id", _idSeleccionado);
+            });
+
+            CargarBodegas();
+            LimpiarFormulario();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al actualizar la bodega: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+}

--- a/ERP 2 evaluacion/ClientesForm.cs
+++ b/ERP 2 evaluacion/ClientesForm.cs
@@ -1,0 +1,308 @@
+using Microsoft.Data.SqlClient;
+using System;
+using System.Data;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ERP_2_evaluacion;
+
+public class ClientesForm : Form
+{
+    private readonly DataGridView _grid = new()
+    {
+        Dock = DockStyle.Fill,
+        ReadOnly = true,
+        SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+        MultiSelect = false,
+        AutoGenerateColumns = false
+    };
+
+    private readonly TextBox _txtNombre = new() { PlaceholderText = "Nombre completo" };
+    private readonly TextBox _txtIdentificacion = new() { PlaceholderText = "Documento" };
+    private readonly TextBox _txtTipoDocumento = new() { PlaceholderText = "Tipo de documento" };
+    private readonly TextBox _txtCorreo = new() { PlaceholderText = "Correo" };
+    private readonly TextBox _txtTelefono = new() { PlaceholderText = "Teléfono" };
+    private readonly TextBox _txtDireccion = new() { PlaceholderText = "Dirección", Multiline = true, Height = 80 };
+    private readonly CheckBox _chkActivo = new() { Text = "Activo", Checked = true };
+
+    private readonly Button _btnNuevo = new() { Text = "Nuevo" };
+    private readonly Button _btnGuardar = new() { Text = "Guardar" };
+    private readonly Button _btnActivar = new() { Text = "Activar" };
+    private readonly Button _btnDesactivar = new() { Text = "Desactivar" };
+
+    private readonly Label _lblMensaje = new() { AutoSize = true, ForeColor = UiTheme.DangerColor };
+
+    private int? _idSeleccionado;
+
+    public ClientesForm()
+    {
+        Text = "Clientes";
+        StartPosition = FormStartPosition.CenterParent;
+        Size = new Size(1200, 780);
+        MinimumSize = new Size(1024, 680);
+
+        UiTheme.ApplyMinimalStyle(this);
+
+        ConfigurarGrid();
+        UiTheme.StyleDataGrid(_grid);
+
+        UiTheme.StyleTextInput(_txtNombre);
+        UiTheme.StyleTextInput(_txtIdentificacion);
+        UiTheme.StyleTextInput(_txtTipoDocumento);
+        UiTheme.StyleTextInput(_txtCorreo);
+        UiTheme.StyleTextInput(_txtTelefono);
+        UiTheme.StyleTextInput(_txtDireccion);
+        UiTheme.StyleCheckBox(_chkActivo);
+
+        UiTheme.StyleSecondaryButton(_btnNuevo);
+        UiTheme.StylePrimaryButton(_btnGuardar);
+        UiTheme.StyleSuccessButton(_btnActivar);
+        UiTheme.StyleDangerButton(_btnDesactivar);
+        _btnGuardar.Margin = new Padding(0);
+
+        var layout = CrearLayout();
+
+        var gridCard = UiTheme.CreateCardPanel();
+        gridCard.Padding = new Padding(32, 32, 32, 24);
+        gridCard.Controls.Add(_grid);
+
+        var split = new SplitContainer
+        {
+            Dock = DockStyle.Fill,
+            Orientation = Orientation.Horizontal,
+            BorderStyle = BorderStyle.None,
+            SplitterWidth = 12
+        };
+        split.Panel1.Controls.Add(gridCard);
+        split.Panel2.Controls.Add(layout);
+
+        Controls.Add(split);
+
+        Load += (_, _) =>
+        {
+            CargarClientes();
+            ActualizarAccionesEstado(null);
+        };
+        _grid.SelectionChanged += (_, _) => CargarSeleccion();
+        _btnNuevo.Click += (_, _) => LimpiarFormulario();
+        _btnGuardar.Click += (_, _) => GuardarCliente();
+        _btnActivar.Click += (_, _) => CambiarEstado(true);
+        _btnDesactivar.Click += (_, _) => CambiarEstado(false);
+    }
+
+    private void ConfigurarGrid()
+    {
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Id", DataPropertyName = "IdCliente", Width = 60 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Nombre", DataPropertyName = "NombreCompleto", AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Documento", DataPropertyName = "Identificacion", Width = 140 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Tipo", DataPropertyName = "TipoDocumento", Width = 120 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Correo", DataPropertyName = "Correo", Width = 200 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Teléfono", DataPropertyName = "Telefono", Width = 140 });
+        _grid.Columns.Add(new DataGridViewCheckBoxColumn { HeaderText = "Activo", DataPropertyName = "Activo", Width = 80 });
+    }
+
+    private Control CrearLayout()
+    {
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 2,
+            Padding = new Padding(0, 0, 0, 16)
+        };
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+
+        layout.Controls.Add(new Label { Text = "Nombre", AutoSize = true, ForeColor = UiTheme.MutedTextColor }, 0, 0);
+        layout.Controls.Add(new Label { Text = "Documento", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 0, 0, 0) }, 1, 0);
+        layout.Controls.Add(_txtNombre, 0, 1);
+        layout.Controls.Add(_txtIdentificacion, 1, 1);
+
+        layout.Controls.Add(new Label { Text = "Tipo de documento", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(0, 12, 0, 0) }, 0, 2);
+        layout.Controls.Add(new Label { Text = "Correo", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 12, 0, 0) }, 1, 2);
+        layout.Controls.Add(_txtTipoDocumento, 0, 3);
+        layout.Controls.Add(_txtCorreo, 1, 3);
+
+        layout.Controls.Add(new Label { Text = "Teléfono", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(0, 12, 0, 0) }, 0, 4);
+        layout.Controls.Add(new Label { Text = "Dirección", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 12, 0, 0) }, 1, 4);
+        layout.Controls.Add(_txtTelefono, 0, 5);
+        layout.Controls.Add(_txtDireccion, 1, 5);
+
+        layout.Controls.Add(_chkActivo, 0, 6);
+        layout.SetColumnSpan(_chkActivo, 2);
+        layout.Controls.Add(_lblMensaje, 0, 7);
+        layout.SetColumnSpan(_lblMensaje, 2);
+
+        var botones = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Bottom,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false,
+            Padding = new Padding(0, 24, 0, 0)
+        };
+        botones.Controls.AddRange(new Control[] { _btnGuardar, _btnNuevo, _btnActivar, _btnDesactivar });
+
+        var card = UiTheme.CreateCardPanel();
+        card.AutoScroll = true;
+        card.Padding = new Padding(32, 32, 32, 24);
+        card.Controls.Add(layout);
+        card.Controls.Add(botones);
+
+        return card;
+    }
+
+    private void CargarClientes()
+    {
+        try
+        {
+            _grid.DataSource = Db.GetDataTable("SELECT IdCliente, NombreCompleto, Identificacion, TipoDocumento, Correo, Telefono, Direccion, Activo FROM Cliente ORDER BY NombreCompleto");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar clientes: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarSeleccion()
+    {
+        if (_grid.SelectedRows.Count == 0)
+        {
+            return;
+        }
+
+        if (_grid.SelectedRows[0].DataBoundItem is DataRowView fila)
+        {
+            _idSeleccionado = (int)fila["IdCliente"];
+            _txtNombre.Text = Convert.ToString(fila["NombreCompleto"]) ?? string.Empty;
+            _txtIdentificacion.Text = Convert.ToString(fila["Identificacion"]) ?? string.Empty;
+            _txtTipoDocumento.Text = Convert.ToString(fila["TipoDocumento"]) ?? string.Empty;
+            _txtCorreo.Text = Convert.ToString(fila["Correo"]) ?? string.Empty;
+            _txtTelefono.Text = Convert.ToString(fila["Telefono"]) ?? string.Empty;
+            _txtDireccion.Text = Convert.ToString(fila["Direccion"]) ?? string.Empty;
+            var activo = fila.Row.Field<bool>("Activo");
+            _chkActivo.Checked = activo;
+            ActualizarAccionesEstado(activo);
+        }
+    }
+
+    private void LimpiarFormulario()
+    {
+        _idSeleccionado = null;
+        _txtNombre.Text = string.Empty;
+        _txtIdentificacion.Text = string.Empty;
+        _txtTipoDocumento.Text = string.Empty;
+        _txtCorreo.Text = string.Empty;
+        _txtTelefono.Text = string.Empty;
+        _txtDireccion.Text = string.Empty;
+        _chkActivo.Checked = true;
+        _lblMensaje.Text = string.Empty;
+        _grid.ClearSelection();
+        ActualizarAccionesEstado(null);
+    }
+
+    private void ActualizarAccionesEstado(bool? activo)
+    {
+        var haySeleccion = _idSeleccionado != null;
+        _btnActivar.Enabled = haySeleccion && activo == false;
+        _btnDesactivar.Enabled = haySeleccion && activo != false;
+    }
+
+    private void GuardarCliente()
+    {
+        _lblMensaje.Text = string.Empty;
+
+        var nombre = _txtNombre.Text.Trim();
+        var identificacion = _txtIdentificacion.Text.Trim();
+        var tipoDocumento = _txtTipoDocumento.Text.Trim();
+        var correo = _txtCorreo.Text.Trim();
+        var telefono = _txtTelefono.Text.Trim();
+        var direccion = _txtDireccion.Text.Trim();
+        var activo = _chkActivo.Checked;
+
+        if (string.IsNullOrWhiteSpace(nombre))
+        {
+            _lblMensaje.Text = "El nombre es obligatorio";
+            return;
+        }
+
+        try
+        {
+            using var connection = Db.GetConnection();
+            connection.Open();
+
+            SqlCommand command;
+            if (_idSeleccionado == null)
+            {
+                command = new SqlCommand(@"INSERT INTO Cliente (NombreCompleto, Identificacion, TipoDocumento, Correo, Telefono, Direccion, Activo)
+VALUES (@nombre, @identificacion, @tipo, @correo, @telefono, @direccion, @activo);", connection);
+            }
+            else
+            {
+                command = new SqlCommand(@"UPDATE Cliente
+SET NombreCompleto = @nombre,
+    Identificacion = @identificacion,
+    TipoDocumento = @tipo,
+    Correo = @correo,
+    Telefono = @telefono,
+    Direccion = @direccion,
+    Activo = @activo
+WHERE IdCliente = @id;", connection);
+                command.Parameters.AddWithValue("@id", _idSeleccionado.Value);
+            }
+
+            command.Parameters.AddWithValue("@nombre", nombre);
+            command.Parameters.AddWithValue("@identificacion", string.IsNullOrWhiteSpace(identificacion) ? DBNull.Value : identificacion);
+            command.Parameters.AddWithValue("@tipo", string.IsNullOrWhiteSpace(tipoDocumento) ? DBNull.Value : tipoDocumento);
+            command.Parameters.AddWithValue("@correo", string.IsNullOrWhiteSpace(correo) ? DBNull.Value : correo);
+            command.Parameters.AddWithValue("@telefono", string.IsNullOrWhiteSpace(telefono) ? DBNull.Value : telefono);
+            command.Parameters.AddWithValue("@direccion", string.IsNullOrWhiteSpace(direccion) ? DBNull.Value : direccion);
+            command.Parameters.AddWithValue("@activo", activo);
+
+            command.ExecuteNonQuery();
+
+            MessageBox.Show("Cliente guardado correctamente", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            LimpiarFormulario();
+            CargarClientes();
+        }
+        catch (SqlException ex) when (ex.Number is 2601 or 2627)
+        {
+            _lblMensaje.Text = "Ya existe un cliente con ese documento";
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al guardar cliente: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CambiarEstado(bool activar)
+    {
+        if (_idSeleccionado == null)
+        {
+            MessageBox.Show("Seleccione un cliente primero", "Atención", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var accion = activar ? "activar" : "desactivar";
+        if (MessageBox.Show($"¿Desea {accion} el cliente seleccionado?", "Confirmación", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+        {
+            return;
+        }
+
+        try
+        {
+            Db.Execute("UPDATE Cliente SET Activo = @activo WHERE IdCliente = @id", p =>
+            {
+                p.AddWithValue("@activo", activar);
+                p.AddWithValue("@id", _idSeleccionado);
+            });
+
+            CargarClientes();
+            LimpiarFormulario();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al actualizar cliente: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+}

--- a/ERP 2 evaluacion/InventarioForm.cs
+++ b/ERP 2 evaluacion/InventarioForm.cs
@@ -1,0 +1,481 @@
+using Microsoft.Data.SqlClient;
+using System;
+using System.Data;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace ERP_2_evaluacion;
+
+public class InventarioForm : Form
+{
+    private readonly int? _idUsuario;
+
+    private readonly ComboBox _cmbBodega = new();
+    private readonly TextBox _txtBuscar = new() { PlaceholderText = "Buscar producto" };
+    private readonly DataGridView _grid = new()
+    {
+        Dock = DockStyle.Fill,
+        ReadOnly = true,
+        SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+        MultiSelect = false,
+        AutoGenerateColumns = false
+    };
+
+    private readonly Button _btnEntrada = new() { Text = "Registrar entrada" };
+    private readonly Button _btnSalida = new() { Text = "Registrar salida" };
+    private readonly Button _btnAjuste = new() { Text = "Ajuste de stock" };
+
+    private readonly Label _lblResumen = new() { AutoSize = true, ForeColor = UiTheme.MutedTextColor };
+    private readonly Label _lblMensaje = new() { AutoSize = true, ForeColor = UiTheme.DangerColor };
+
+    private DataTable? _inventario;
+
+    public InventarioForm(int? idUsuario = null)
+    {
+        _idUsuario = idUsuario;
+
+        Text = "Inventario";
+        StartPosition = FormStartPosition.CenterParent;
+        Size = new Size(1280, 840);
+        MinimumSize = new Size(1120, 720);
+
+        UiTheme.ApplyMinimalStyle(this);
+
+        UiTheme.StyleComboBox(_cmbBodega);
+        _cmbBodega.Dock = DockStyle.Fill;
+        UiTheme.StyleTextInput(_txtBuscar);
+        UiTheme.StyleDataGrid(_grid);
+
+        UiTheme.StyleSecondaryButton(_btnEntrada);
+        UiTheme.StyleSecondaryButton(_btnSalida);
+        UiTheme.StyleSecondaryButton(_btnAjuste);
+        _btnEntrada.Margin = new Padding(0, 0, 12, 0);
+        _btnSalida.Margin = new Padding(0, 0, 12, 0);
+
+        ConfigurarGrid();
+
+        var layout = CrearLayout();
+        Controls.Add(layout);
+
+        Load += InventarioForm_Load;
+        _cmbBodega.SelectedIndexChanged += (_, _) => CargarInventario();
+        _txtBuscar.TextChanged += (_, _) => CargarInventario();
+        _btnEntrada.Click += (_, _) => RegistrarMovimiento(TipoMovimiento.Entrada);
+        _btnSalida.Click += (_, _) => RegistrarMovimiento(TipoMovimiento.Salida);
+        _btnAjuste.Click += (_, _) => RegistrarMovimiento(TipoMovimiento.Ajuste);
+    }
+
+    private void InventarioForm_Load(object? sender, EventArgs e)
+    {
+        CargarBodegas();
+        CargarInventario();
+    }
+
+    private void ConfigurarGrid()
+    {
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Id", DataPropertyName = "IdInventario", Width = 60 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Código", DataPropertyName = "Codigo", Width = 120 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Producto", DataPropertyName = "Nombre", AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Stock", DataPropertyName = "StockActual", Width = 120 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Reservado", DataPropertyName = "StockReservado", Width = 120 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Stock mínimo", DataPropertyName = "StockMinimo", Width = 120 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Stock máximo", DataPropertyName = "StockMaximo", Width = 120 });
+    }
+
+    private Control CrearLayout()
+    {
+        var root = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 1
+        };
+        root.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+
+        var card = UiTheme.CreateCardPanel();
+        card.Padding = new Padding(32, 32, 32, 24);
+
+        var content = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 5,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink
+        };
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+
+        var header = new TableLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            ColumnCount = 2,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink
+        };
+        header.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        header.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+
+        header.Controls.Add(UiTheme.CreateSectionLabel("Bodega"), 0, 0);
+        header.Controls.Add(UiTheme.CreateSectionLabel("Buscar"), 1, 0);
+        header.Controls.Add(_cmbBodega, 0, 1);
+        header.Controls.Add(_txtBuscar, 1, 1);
+
+        var resumenPanel = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.LeftToRight,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false,
+            Margin = new Padding(0, 16, 0, 0)
+        };
+        resumenPanel.Controls.Add(_lblResumen);
+
+        var botones = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.LeftToRight,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false,
+            Margin = new Padding(0, 16, 0, 0)
+        };
+        botones.Controls.AddRange(new Control[] { _btnEntrada, _btnSalida, _btnAjuste });
+
+        _lblMensaje.Margin = new Padding(0, 16, 0, 0);
+        _grid.Margin = new Padding(0, 24, 0, 0);
+        _grid.Dock = DockStyle.Fill;
+
+        content.Controls.Add(header, 0, 0);
+        content.Controls.Add(resumenPanel, 0, 1);
+        content.Controls.Add(botones, 0, 2);
+        content.Controls.Add(_lblMensaje, 0, 3);
+        content.Controls.Add(_grid, 0, 4);
+
+        card.Controls.Add(content);
+
+        root.Controls.Add(card, 0, 0);
+
+        return root;
+    }
+
+    private void CargarBodegas()
+    {
+        try
+        {
+            var bodegas = Db.GetDataTable("SELECT IdBodega, Nombre FROM Bodega WHERE Activo = 1 ORDER BY Nombre");
+            _cmbBodega.DisplayMember = "Nombre";
+            _cmbBodega.ValueMember = "IdBodega";
+            _cmbBodega.DataSource = bodegas;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar bodegas: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarInventario()
+    {
+        if (_cmbBodega.SelectedValue is not int idBodega)
+        {
+            _grid.DataSource = null;
+            _lblResumen.Text = "Seleccione una bodega para ver el inventario.";
+            return;
+        }
+
+        var filtro = _txtBuscar.Text.Trim();
+
+        try
+        {
+            _inventario = Db.GetDataTable(@"SELECT i.IdInventario,
+       p.Codigo,
+       p.Nombre,
+       i.StockActual,
+       i.StockReservado,
+       i.StockMinimo,
+       i.StockMaximo
+FROM Inventario i
+JOIN Producto p ON p.IdProducto = i.IdProducto
+WHERE i.IdBodega = @bodega
+  AND (@filtro = '' OR p.Nombre LIKE @patron OR p.Codigo LIKE @patron)
+ORDER BY p.Nombre",
+                p =>
+                {
+                    p.AddWithValue("@bodega", idBodega);
+                    p.AddWithValue("@filtro", filtro);
+                    p.AddWithValue("@patron", $"%{filtro}%");
+                });
+
+            _grid.DataSource = _inventario;
+            ActualizarResumen();
+            _lblMensaje.Text = string.Empty;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar inventario: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void ActualizarResumen()
+    {
+        if (_inventario == null || _inventario.Rows.Count == 0)
+        {
+            _lblResumen.Text = "No hay productos con inventario registrado en la bodega seleccionada.";
+            return;
+        }
+
+        var totalProductos = _inventario.Rows.Count;
+        var totalUnidades = _inventario.AsEnumerable().Sum(row => row.Field<decimal>("StockActual"));
+        _lblResumen.Text = $"Productos: {totalProductos} | Unidades disponibles: {totalUnidades.ToString("N2", CultureInfo.CurrentCulture)}";
+    }
+
+    private void RegistrarMovimiento(TipoMovimiento tipo)
+    {
+        if (!TryObtenerSeleccion(out var idInventario, out var producto, out var stockActual))
+        {
+            return;
+        }
+
+        var dialogo = new MovimientoDialog(tipo, producto, stockActual);
+        if (dialogo.ShowDialog(this) != DialogResult.OK)
+        {
+            return;
+        }
+
+        try
+        {
+            using var connection = Db.GetConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+
+            decimal nuevoStock;
+            decimal cantidadMovimiento;
+            switch (tipo)
+            {
+                case TipoMovimiento.Entrada:
+                    nuevoStock = stockActual + dialogo.Cantidad;
+                    cantidadMovimiento = dialogo.Cantidad;
+                    EjecutarActualizacionInventario(connection, transaction, idInventario, nuevoStock);
+                    RegistrarMovimientoInventario(connection, transaction, idInventario, "ENTRADA", cantidadMovimiento, dialogo.Motivo);
+                    break;
+                case TipoMovimiento.Salida:
+                    if (dialogo.Cantidad > stockActual)
+                    {
+                        throw new InvalidOperationException("La cantidad a retirar supera el stock disponible");
+                    }
+                    nuevoStock = stockActual - dialogo.Cantidad;
+                    cantidadMovimiento = dialogo.Cantidad;
+                    EjecutarActualizacionInventario(connection, transaction, idInventario, nuevoStock);
+                    RegistrarMovimientoInventario(connection, transaction, idInventario, "SALIDA", cantidadMovimiento, dialogo.Motivo);
+                    break;
+                case TipoMovimiento.Ajuste:
+                    nuevoStock = dialogo.NuevoStock;
+                    if (Math.Abs(nuevoStock - stockActual) < 0.0001m)
+                    {
+                        throw new InvalidOperationException("El ajuste no modifica el stock actual");
+                    }
+                    cantidadMovimiento = Math.Abs(nuevoStock - stockActual);
+                    EjecutarActualizacionInventario(connection, transaction, idInventario, nuevoStock);
+                    RegistrarMovimientoInventario(connection, transaction, idInventario, "AJUSTE", cantidadMovimiento, dialogo.Motivo + $" (antes: {stockActual}, ahora: {nuevoStock})");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(tipo));
+            }
+
+            transaction.Commit();
+            CargarInventario();
+            _lblMensaje.ForeColor = UiTheme.AccentColor;
+            _lblMensaje.Text = tipo switch
+            {
+                TipoMovimiento.Entrada => $"Entrada registrada por {dialogo.Cantidad.ToString("N2", CultureInfo.CurrentCulture)} unidades.",
+                TipoMovimiento.Salida => $"Salida registrada por {dialogo.Cantidad.ToString("N2", CultureInfo.CurrentCulture)} unidades.",
+                _ => "Ajuste de inventario registrado correctamente."
+            };
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al registrar movimiento: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private static void EjecutarActualizacionInventario(SqlConnection connection, SqlTransaction transaction, int idInventario, decimal nuevoStock)
+    {
+        using var command = new SqlCommand("UPDATE Inventario SET StockActual = @stock, FechaActualizacion = GETDATE() WHERE IdInventario = @id", connection, transaction);
+        command.Parameters.AddWithValue("@stock", nuevoStock);
+        command.Parameters.AddWithValue("@id", idInventario);
+        command.ExecuteNonQuery();
+    }
+
+    private void RegistrarMovimientoInventario(SqlConnection connection, SqlTransaction transaction, int idInventario, string tipo, decimal cantidad, string motivo)
+    {
+        using var command = new SqlCommand(@"INSERT INTO MovimientoInventario (IdInventario, TipoMovimiento, Cantidad, Motivo, Referencia, IdUsuario)
+VALUES (@inventario, @tipo, @cantidad, @motivo, @referencia, @usuario);", connection, transaction);
+        command.Parameters.AddWithValue("@inventario", idInventario);
+        command.Parameters.AddWithValue("@tipo", tipo);
+        command.Parameters.AddWithValue("@cantidad", cantidad);
+        command.Parameters.AddWithValue("@motivo", string.IsNullOrWhiteSpace(motivo) ? DBNull.Value : motivo.Trim());
+        command.Parameters.AddWithValue("@referencia", DBNull.Value);
+        command.Parameters.AddWithValue("@usuario", _idUsuario.HasValue ? _idUsuario.Value : DBNull.Value);
+        command.ExecuteNonQuery();
+    }
+
+    private bool TryObtenerSeleccion(out int idInventario, out string producto, out decimal stockActual)
+    {
+        idInventario = 0;
+        producto = string.Empty;
+        stockActual = 0m;
+
+        if (_grid.SelectedRows.Count == 0)
+        {
+            MessageBox.Show("Seleccione un producto del inventario", "Atención", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return false;
+        }
+
+        if (_grid.SelectedRows[0].DataBoundItem is not DataRowView fila)
+        {
+            return false;
+        }
+
+        idInventario = fila.Row.Field<int>("IdInventario");
+        producto = fila.Row.Field<string>("Nombre");
+        stockActual = fila.Row.Field<decimal>("StockActual");
+        return true;
+    }
+
+    private enum TipoMovimiento
+    {
+        Entrada,
+        Salida,
+        Ajuste
+    }
+
+    private sealed class MovimientoDialog : Form
+    {
+        private readonly NumericUpDown _nudCantidad = new()
+        {
+            DecimalPlaces = 2,
+            Minimum = 0,
+            Maximum = 1_000_000,
+            Increment = 1,
+            Dock = DockStyle.Fill
+        };
+
+        private readonly TextBox _txtMotivo = new() { PlaceholderText = "Motivo" };
+        private readonly bool _esAjuste;
+        private readonly decimal _stockActual;
+
+        public decimal Cantidad => _nudCantidad.Value;
+        public decimal NuevoStock => _esAjuste ? _nudCantidad.Value : _stockActual;
+        public string Motivo => _txtMotivo.Text.Trim();
+
+        public MovimientoDialog(TipoMovimiento tipo, string producto, decimal stockActual)
+        {
+            _esAjuste = tipo == TipoMovimiento.Ajuste;
+            _stockActual = stockActual;
+
+            Text = tipo switch
+            {
+                TipoMovimiento.Entrada => "Registrar entrada",
+                TipoMovimiento.Salida => "Registrar salida",
+                _ => "Ajustar stock"
+            };
+            StartPosition = FormStartPosition.CenterParent;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Size = new Size(420, 280);
+
+            UiTheme.ApplyMinimalStyle(this);
+
+            UiTheme.StyleTextInput(_txtMotivo);
+            _txtMotivo.Margin = new Padding(0, 12, 0, 12);
+
+            var lblProducto = new Label
+            {
+                Text = $"Producto: {producto}",
+                AutoSize = true,
+                ForeColor = UiTheme.MutedTextColor
+            };
+            var lblActual = new Label
+            {
+                Text = $"Stock actual: {stockActual.ToString("N2", CultureInfo.CurrentCulture)}",
+                AutoSize = true,
+                ForeColor = UiTheme.MutedTextColor,
+                Margin = new Padding(0, 6, 0, 0)
+            };
+
+            var lblCantidad = new Label
+            {
+                Text = _esAjuste ? "Nuevo stock" : "Cantidad",
+                AutoSize = true,
+                ForeColor = UiTheme.MutedTextColor,
+                Margin = new Padding(0, 12, 0, 0)
+            };
+
+            if (_esAjuste)
+            {
+                _nudCantidad.Value = stockActual;
+            }
+
+            var btnAceptar = new Button { Text = "Aceptar", DialogResult = DialogResult.OK };
+            var btnCancelar = new Button { Text = "Cancelar", DialogResult = DialogResult.Cancel };
+            UiTheme.StylePrimaryButton(btnAceptar);
+            UiTheme.StyleSecondaryButton(btnCancelar);
+            btnAceptar.Margin = new Padding(0, 0, 8, 0);
+
+            var botones = new FlowLayoutPanel
+            {
+                FlowDirection = FlowDirection.RightToLeft,
+                Dock = DockStyle.Bottom,
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                WrapContents = false,
+                Margin = new Padding(0, 24, 0, 0)
+            };
+            botones.Controls.Add(btnAceptar);
+            botones.Controls.Add(btnCancelar);
+
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 1,
+                RowCount = 7
+            };
+            for (int i = 0; i < 7; i++)
+            {
+                layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            }
+
+            layout.Controls.Add(lblProducto, 0, 0);
+            layout.Controls.Add(lblActual, 0, 1);
+            layout.Controls.Add(lblCantidad, 0, 2);
+            layout.Controls.Add(_nudCantidad, 0, 3);
+            layout.Controls.Add(new Label { Text = "Motivo", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(0, 12, 0, 0) }, 0, 4);
+            layout.Controls.Add(_txtMotivo, 0, 5);
+            layout.Controls.Add(botones, 0, 6);
+
+            Controls.Add(layout);
+
+            AcceptButton = btnAceptar;
+            CancelButton = btnCancelar;
+
+            btnAceptar.Click += (_, _) =>
+            {
+                if (_esAjuste && _nudCantidad.Value < 0)
+                {
+                    MessageBox.Show("El stock no puede ser negativo", "Validación", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    DialogResult = DialogResult.None;
+                }
+                else if (!_esAjuste && _nudCantidad.Value <= 0)
+                {
+                    MessageBox.Show("Ingrese una cantidad mayor a cero", "Validación", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    DialogResult = DialogResult.None;
+                }
+            };
+        }
+    }
+}

--- a/ERP 2 evaluacion/PrincipalForm.cs
+++ b/ERP 2 evaluacion/PrincipalForm.cs
@@ -25,6 +25,11 @@ namespace ERP_2_evaluacion
         private readonly Button _btnIrUsuarios = new();
         private readonly Button _btnIrPerfiles = new();
         private readonly Button _btnIrAccesos = new();
+        private readonly Button _btnIrProductos = new();
+        private readonly Button _btnIrInventario = new();
+        private readonly Button _btnIrVentas = new();
+        private readonly Button _btnIrClientes = new();
+        private readonly Button _btnIrBodegas = new();
         private readonly string _heroSubtitleDefault = "Gestiona tus módulos y accesos desde un solo lugar";
         private List<PantallaNodo> _pantallasDisponibles = new();
 
@@ -472,10 +477,20 @@ ORDER BY CASE WHEN p.IdPadre IS NULL THEN 0 ELSE 1 END,
             ConfigurarBotonAccion(_btnIrUsuarios, "Usuarios", "Gestiona cuentas y credenciales", "USUARIOS");
             ConfigurarBotonAccion(_btnIrPerfiles, "Perfiles", "Administra roles y perfiles", "PERFILES");
             ConfigurarBotonAccion(_btnIrAccesos, "Accesos", "Configura permisos por pantalla", "ACCESOS");
+            ConfigurarBotonAccion(_btnIrProductos, "Productos", "Catálogo y precios de productos", "PRODUCTOS");
+            ConfigurarBotonAccion(_btnIrBodegas, "Bodegas", "Organiza tus almacenes", "BODEGAS");
+            ConfigurarBotonAccion(_btnIrInventario, "Inventario", "Controla existencias y movimientos", "INVENTARIO");
+            ConfigurarBotonAccion(_btnIrClientes, "Clientes", "Administra tu cartera de clientes", "CLIENTES");
+            ConfigurarBotonAccion(_btnIrVentas, "Ventas", "Registra ventas rápidamente", "VENTAS");
 
             panel.Controls.Add(_btnIrUsuarios);
             panel.Controls.Add(_btnIrPerfiles);
             panel.Controls.Add(_btnIrAccesos);
+            panel.Controls.Add(_btnIrProductos);
+            panel.Controls.Add(_btnIrBodegas);
+            panel.Controls.Add(_btnIrInventario);
+            panel.Controls.Add(_btnIrClientes);
+            panel.Controls.Add(_btnIrVentas);
 
             return panel;
         }
@@ -513,6 +528,11 @@ ORDER BY CASE WHEN p.IdPadre IS NULL THEN 0 ELSE 1 END,
                 "USUARIOS" => new UsuariosForm(_usuarioPrivilegiado),
                 "PERFILES" => new PerfilesForm(),
                 "ACCESOS" => new AccesosForm(),
+                "PRODUCTOS" => new ProductosForm(),
+                "BODEGAS" => new BodegasForm(),
+                "INVENTARIO" => new InventarioForm(_idUsuario),
+                "CLIENTES" => new ClientesForm(),
+                "VENTAS" => new VentasForm(_idUsuario),
                 _ => null
             };
 
@@ -532,10 +552,20 @@ ORDER BY CASE WHEN p.IdPadre IS NULL THEN 0 ELSE 1 END,
             bool tieneUsuarios = _pantallasDisponibles.Any(p => string.Equals(p.Codigo, "USUARIOS", StringComparison.OrdinalIgnoreCase));
             bool tienePerfiles = _pantallasDisponibles.Any(p => string.Equals(p.Codigo, "PERFILES", StringComparison.OrdinalIgnoreCase));
             bool tieneAccesos = _pantallasDisponibles.Any(p => string.Equals(p.Codigo, "ACCESOS", StringComparison.OrdinalIgnoreCase));
+            bool tieneProductos = _pantallasDisponibles.Any(p => string.Equals(p.Codigo, "PRODUCTOS", StringComparison.OrdinalIgnoreCase));
+            bool tieneBodegas = _pantallasDisponibles.Any(p => string.Equals(p.Codigo, "BODEGAS", StringComparison.OrdinalIgnoreCase));
+            bool tieneInventario = _pantallasDisponibles.Any(p => string.Equals(p.Codigo, "INVENTARIO", StringComparison.OrdinalIgnoreCase));
+            bool tieneClientes = _pantallasDisponibles.Any(p => string.Equals(p.Codigo, "CLIENTES", StringComparison.OrdinalIgnoreCase));
+            bool tieneVentas = _pantallasDisponibles.Any(p => string.Equals(p.Codigo, "VENTAS", StringComparison.OrdinalIgnoreCase));
 
             _btnIrUsuarios.Enabled = tieneUsuarios;
             _btnIrPerfiles.Enabled = tienePerfiles;
             _btnIrAccesos.Enabled = tieneAccesos;
+            _btnIrProductos.Enabled = tieneProductos;
+            _btnIrBodegas.Enabled = tieneBodegas;
+            _btnIrInventario.Enabled = tieneInventario;
+            _btnIrClientes.Enabled = tieneClientes;
+            _btnIrVentas.Enabled = tieneVentas;
         }
 
         private Panel CrearChipEstadistica(string titulo, Label valorLabel)

--- a/ERP 2 evaluacion/ProductosForm.cs
+++ b/ERP 2 evaluacion/ProductosForm.cs
@@ -1,0 +1,586 @@
+using Microsoft.Data.SqlClient;
+using System;
+using System.Data;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace ERP_2_evaluacion;
+
+public class ProductosForm : Form
+{
+    private readonly DataGridView _grid = new()
+    {
+        Dock = DockStyle.Fill,
+        ReadOnly = true,
+        SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+        MultiSelect = false,
+        AutoGenerateColumns = false
+    };
+
+    private readonly TextBox _txtCodigo = new() { PlaceholderText = "Código" };
+    private readonly TextBox _txtNombre = new() { PlaceholderText = "Nombre" };
+    private readonly TextBox _txtDescripcion = new() { PlaceholderText = "Descripción", Multiline = true, Height = 80 };
+    private readonly ComboBox _cmbCategoria = new();
+    private readonly Button _btnNuevaCategoria = new() { Text = "Nueva categoría" };
+    private readonly TextBox _txtPrecioCosto = new() { PlaceholderText = "Precio costo" };
+    private readonly TextBox _txtPrecioVenta = new() { PlaceholderText = "Precio venta" };
+    private readonly TextBox _txtStockMinimo = new() { PlaceholderText = "Stock mínimo" };
+    private readonly TextBox _txtStockMaximo = new() { PlaceholderText = "Stock máximo" };
+    private readonly CheckBox _chkActivo = new() { Text = "Activo", Checked = true };
+
+    private readonly Button _btnNuevo = new() { Text = "Nuevo" };
+    private readonly Button _btnGuardar = new() { Text = "Guardar" };
+    private readonly Button _btnActivar = new() { Text = "Activar" };
+    private readonly Button _btnDesactivar = new() { Text = "Desactivar" };
+
+    private readonly Label _lblMensaje = new() { AutoSize = true, ForeColor = UiTheme.DangerColor };
+
+    private DataTable? _categorias;
+    private int? _idSeleccionado;
+
+    public ProductosForm()
+    {
+        Text = "Productos";
+        StartPosition = FormStartPosition.CenterParent;
+        Size = new Size(1280, 840);
+        MinimumSize = new Size(1120, 720);
+
+        UiTheme.ApplyMinimalStyle(this);
+
+        ConfigurarGrid();
+        UiTheme.StyleDataGrid(_grid);
+
+        UiTheme.StyleTextInput(_txtCodigo);
+        UiTheme.StyleTextInput(_txtNombre);
+        UiTheme.StyleTextInput(_txtDescripcion);
+        UiTheme.StyleComboBox(_cmbCategoria);
+        _cmbCategoria.Dock = DockStyle.None;
+        _cmbCategoria.Width = 240;
+        UiTheme.StyleTextInput(_txtPrecioCosto);
+        UiTheme.StyleTextInput(_txtPrecioVenta);
+        UiTheme.StyleTextInput(_txtStockMinimo);
+        UiTheme.StyleTextInput(_txtStockMaximo);
+        UiTheme.StyleCheckBox(_chkActivo);
+
+        UiTheme.StyleSecondaryButton(_btnNuevaCategoria);
+        _btnNuevaCategoria.Margin = new Padding(12, 0, 0, 0);
+        UiTheme.StyleSecondaryButton(_btnNuevo);
+        UiTheme.StylePrimaryButton(_btnGuardar);
+        UiTheme.StyleSuccessButton(_btnActivar);
+        UiTheme.StyleDangerButton(_btnDesactivar);
+        _btnGuardar.Margin = new Padding(0);
+
+        var layout = CrearLayout();
+
+        var gridCard = UiTheme.CreateCardPanel();
+        gridCard.Padding = new Padding(32, 32, 32, 24);
+        gridCard.Controls.Add(_grid);
+
+        var split = new SplitContainer
+        {
+            Dock = DockStyle.Fill,
+            Orientation = Orientation.Horizontal,
+            BorderStyle = BorderStyle.None,
+            SplitterWidth = 12
+        };
+        split.Panel1.Controls.Add(gridCard);
+        split.Panel2.Controls.Add(layout);
+
+        Controls.Add(split);
+
+        Load += ProductosForm_Load;
+        _grid.SelectionChanged += (_, _) => CargarSeleccion();
+        _btnNuevo.Click += (_, _) => LimpiarFormulario();
+        _btnGuardar.Click += (_, _) => GuardarProducto();
+        _btnActivar.Click += (_, _) => CambiarEstado(true);
+        _btnDesactivar.Click += (_, _) => CambiarEstado(false);
+        _btnNuevaCategoria.Click += (_, _) => CrearCategoria();
+    }
+
+    private void ProductosForm_Load(object? sender, EventArgs e)
+    {
+        CargarCategorias();
+        CargarProductos();
+        ActualizarAccionesEstado(null);
+    }
+
+    private void ConfigurarGrid()
+    {
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Id", DataPropertyName = "IdProducto", Width = 60 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Código", DataPropertyName = "Codigo", Width = 120 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Nombre", DataPropertyName = "Nombre", AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Categoría", DataPropertyName = "Categoria", Width = 180 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Precio venta", DataPropertyName = "PrecioVenta", Width = 120, DefaultCellStyle = new DataGridViewCellStyle { Format = "C2" } });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Stock mínimo", DataPropertyName = "StockMinimo", Width = 120 });
+        _grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Stock máximo", DataPropertyName = "StockMaximo", Width = 120 });
+        _grid.Columns.Add(new DataGridViewCheckBoxColumn { HeaderText = "Activo", DataPropertyName = "Activo", Width = 80 });
+    }
+
+    private Control CrearLayout()
+    {
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 4,
+            Padding = new Padding(0, 0, 0, 16)
+        };
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25));
+
+        int row = 0;
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(new Label { Text = "Código", AutoSize = true, ForeColor = UiTheme.MutedTextColor }, 0, row);
+        layout.Controls.Add(new Label { Text = "Nombre", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 0, 0, 0) }, 1, row);
+        row++;
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(_txtCodigo, 0, row);
+        layout.SetColumnSpan(_txtCodigo, 1);
+        layout.Controls.Add(_txtNombre, 1, row);
+        layout.SetColumnSpan(_txtNombre, 3);
+        row++;
+
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(new Label { Text = "Categoría", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(0, 12, 0, 0) }, 0, row);
+        layout.Controls.Add(new Label { Text = "Descripción", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 12, 0, 0) }, 1, row);
+        row++;
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        var categoriaPanel = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.LeftToRight,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false,
+            Margin = new Padding(0, 0, 0, 0)
+        };
+        categoriaPanel.Controls.Add(_cmbCategoria);
+        categoriaPanel.Controls.Add(_btnNuevaCategoria);
+        layout.Controls.Add(categoriaPanel, 0, row);
+        layout.SetColumnSpan(categoriaPanel, 1);
+        layout.Controls.Add(_txtDescripcion, 1, row);
+        layout.SetColumnSpan(_txtDescripcion, 3);
+        row++;
+
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(new Label { Text = "Precio costo", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(0, 12, 0, 0) }, 0, row);
+        layout.Controls.Add(new Label { Text = "Precio venta", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 12, 0, 0) }, 1, row);
+        layout.Controls.Add(new Label { Text = "Stock mínimo", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 12, 0, 0) }, 2, row);
+        layout.Controls.Add(new Label { Text = "Stock máximo", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(16, 12, 0, 0) }, 3, row);
+        row++;
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(_txtPrecioCosto, 0, row);
+        layout.Controls.Add(_txtPrecioVenta, 1, row);
+        layout.Controls.Add(_txtStockMinimo, 2, row);
+        layout.Controls.Add(_txtStockMaximo, 3, row);
+        row++;
+
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(_chkActivo, 0, row);
+        layout.SetColumnSpan(_chkActivo, 4);
+        row++;
+
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(_lblMensaje, 0, row);
+        layout.SetColumnSpan(_lblMensaje, 4);
+
+        var botones = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Bottom,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false,
+            Padding = new Padding(0, 24, 0, 0)
+        };
+        botones.Controls.AddRange(new Control[] { _btnGuardar, _btnNuevo, _btnActivar, _btnDesactivar });
+
+        var card = UiTheme.CreateCardPanel();
+        card.AutoScroll = true;
+        card.Padding = new Padding(32, 32, 32, 24);
+        card.Controls.Add(layout);
+        card.Controls.Add(botones);
+
+        return card;
+    }
+
+    private void CargarCategorias()
+    {
+        try
+        {
+            _categorias = Db.GetDataTable("SELECT IdCategoria, Nombre FROM CategoriaProducto WHERE Activo = 1 ORDER BY Nombre");
+            _cmbCategoria.DisplayMember = "Nombre";
+            _cmbCategoria.ValueMember = "IdCategoria";
+            _cmbCategoria.DataSource = _categorias;
+            if (_categorias.Rows.Count == 0)
+            {
+                _cmbCategoria.SelectedIndex = -1;
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar categorías: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarProductos()
+    {
+        try
+        {
+            _grid.DataSource = Db.GetDataTable(@"SELECT p.IdProducto,
+       p.Codigo,
+       p.Nombre,
+       p.Descripcion,
+       p.IdCategoria,
+       p.PrecioCosto,
+       p.PrecioVenta,
+       p.StockMinimo,
+       p.StockMaximo,
+       p.Activo,
+       ISNULL(c.Nombre, 'Sin categoría') AS Categoria
+FROM Producto p
+LEFT JOIN CategoriaProducto c ON c.IdCategoria = p.IdCategoria
+ORDER BY p.Nombre");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar productos: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarSeleccion()
+    {
+        if (_grid.SelectedRows.Count == 0)
+        {
+            return;
+        }
+
+        if (_grid.SelectedRows[0].DataBoundItem is DataRowView fila)
+        {
+            _idSeleccionado = (int)fila["IdProducto"];
+            _txtCodigo.Text = Convert.ToString(fila["Codigo"]) ?? string.Empty;
+            _txtNombre.Text = Convert.ToString(fila["Nombre"]) ?? string.Empty;
+            _txtDescripcion.Text = Convert.ToString(fila["Descripcion"]) ?? string.Empty;
+            _txtPrecioCosto.Text = Convert.ToString(fila["PrecioCosto"]) ?? string.Empty;
+            _txtPrecioVenta.Text = Convert.ToString(fila["PrecioVenta"]) ?? string.Empty;
+            _txtStockMinimo.Text = Convert.ToString(fila["StockMinimo"]) ?? string.Empty;
+            _txtStockMaximo.Text = Convert.ToString(fila["StockMaximo"]) ?? string.Empty;
+            var activo = fila.Row.Field<bool>("Activo");
+            _chkActivo.Checked = activo;
+            ActualizarAccionesEstado(activo);
+
+            var idCategoria = fila["IdCategoria"] == DBNull.Value ? (int?)null : Convert.ToInt32(fila["IdCategoria"]);
+            if (idCategoria.HasValue && _categorias != null)
+            {
+                _cmbCategoria.SelectedValue = idCategoria.Value;
+            }
+            else if (_categorias != null)
+            {
+                _cmbCategoria.SelectedIndex = -1;
+            }
+        }
+    }
+
+    private void LimpiarFormulario()
+    {
+        _idSeleccionado = null;
+        _txtCodigo.Text = string.Empty;
+        _txtNombre.Text = string.Empty;
+        _txtDescripcion.Text = string.Empty;
+        _txtPrecioCosto.Text = string.Empty;
+        _txtPrecioVenta.Text = string.Empty;
+        _txtStockMinimo.Text = string.Empty;
+        _txtStockMaximo.Text = string.Empty;
+        _chkActivo.Checked = true;
+        _lblMensaje.Text = string.Empty;
+        if (_categorias != null && _categorias.Rows.Count > 0)
+        {
+            _cmbCategoria.SelectedIndex = 0;
+        }
+        else
+        {
+            _cmbCategoria.SelectedIndex = -1;
+        }
+        _grid.ClearSelection();
+        ActualizarAccionesEstado(null);
+    }
+
+    private void ActualizarAccionesEstado(bool? activo)
+    {
+        var haySeleccion = _idSeleccionado != null;
+        _btnActivar.Enabled = haySeleccion && activo == false;
+        _btnDesactivar.Enabled = haySeleccion && activo != false;
+    }
+
+    private void GuardarProducto()
+    {
+        _lblMensaje.Text = string.Empty;
+
+        var codigo = _txtCodigo.Text.Trim();
+        var nombre = _txtNombre.Text.Trim();
+        var descripcion = _txtDescripcion.Text.Trim();
+        var precioCostoTexto = _txtPrecioCosto.Text.Trim();
+        var precioVentaTexto = _txtPrecioVenta.Text.Trim();
+        var stockMinimoTexto = _txtStockMinimo.Text.Trim();
+        var stockMaximoTexto = _txtStockMaximo.Text.Trim();
+        var activo = _chkActivo.Checked;
+
+        if (string.IsNullOrWhiteSpace(codigo) || string.IsNullOrWhiteSpace(nombre))
+        {
+            _lblMensaje.Text = "Código y nombre son obligatorios";
+            return;
+        }
+
+        if (_cmbCategoria.SelectedValue is not int idCategoria)
+        {
+            _lblMensaje.Text = "Seleccione una categoría";
+            return;
+        }
+
+        if (!decimal.TryParse(precioCostoTexto, NumberStyles.Number, CultureInfo.CurrentCulture, out var precioCosto) || precioCosto < 0)
+        {
+            _lblMensaje.Text = "Precio de costo inválido";
+            return;
+        }
+
+        if (!decimal.TryParse(precioVentaTexto, NumberStyles.Number, CultureInfo.CurrentCulture, out var precioVenta) || precioVenta <= 0)
+        {
+            _lblMensaje.Text = "Precio de venta inválido";
+            return;
+        }
+
+        if (!decimal.TryParse(stockMinimoTexto.Length == 0 ? "0" : stockMinimoTexto, NumberStyles.Number, CultureInfo.CurrentCulture, out var stockMinimo) || stockMinimo < 0)
+        {
+            _lblMensaje.Text = "Stock mínimo inválido";
+            return;
+        }
+
+        decimal? stockMaximo = null;
+        if (stockMaximoTexto.Length > 0)
+        {
+            if (!decimal.TryParse(stockMaximoTexto, NumberStyles.Number, CultureInfo.CurrentCulture, out var valorMax) || valorMax < 0)
+            {
+                _lblMensaje.Text = "Stock máximo inválido";
+                return;
+            }
+            stockMaximo = valorMax;
+        }
+
+        try
+        {
+            using var connection = Db.GetConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+
+            int productoId;
+            using (var command = new SqlCommand
+                   {
+                       Connection = connection,
+                       Transaction = transaction
+                   })
+            {
+                if (_idSeleccionado == null)
+                {
+                    command.CommandText = @"INSERT INTO Producto (Codigo, Nombre, Descripcion, IdCategoria, PrecioCosto, PrecioVenta, StockMinimo, StockMaximo, Activo)
+VALUES (@codigo, @nombre, @descripcion, @categoria, @precioCosto, @precioVenta, @stockMinimo, @stockMaximo, @activo);
+SELECT CAST(SCOPE_IDENTITY() AS INT);";
+                }
+                else
+                {
+                    command.CommandText = @"UPDATE Producto
+SET Codigo = @codigo,
+    Nombre = @nombre,
+    Descripcion = @descripcion,
+    IdCategoria = @categoria,
+    PrecioCosto = @precioCosto,
+    PrecioVenta = @precioVenta,
+    StockMinimo = @stockMinimo,
+    StockMaximo = @stockMaximo,
+    Activo = @activo
+WHERE IdProducto = @id;
+SELECT @id;";
+                    command.Parameters.AddWithValue("@id", _idSeleccionado.Value);
+                }
+
+                command.Parameters.AddWithValue("@codigo", codigo);
+                command.Parameters.AddWithValue("@nombre", nombre);
+                command.Parameters.AddWithValue("@descripcion", string.IsNullOrWhiteSpace(descripcion) ? DBNull.Value : descripcion);
+                command.Parameters.AddWithValue("@categoria", idCategoria);
+                command.Parameters.AddWithValue("@precioCosto", precioCosto);
+                command.Parameters.AddWithValue("@precioVenta", precioVenta);
+                command.Parameters.AddWithValue("@stockMinimo", stockMinimo);
+                command.Parameters.AddWithValue("@stockMaximo", (object?)stockMaximo ?? DBNull.Value);
+                command.Parameters.AddWithValue("@activo", activo);
+
+                var resultado = command.ExecuteScalar();
+                if (resultado == null)
+                {
+                    throw new InvalidOperationException("No se pudo obtener el identificador del producto");
+                }
+
+                productoId = Convert.ToInt32(resultado);
+            }
+
+            AsegurarInventarioParaProducto(connection, transaction, productoId, stockMinimo, stockMaximo);
+
+            transaction.Commit();
+
+            MessageBox.Show("Producto guardado correctamente", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            LimpiarFormulario();
+            CargarProductos();
+        }
+        catch (SqlException ex) when (ex.Number is 2601 or 2627)
+        {
+            _lblMensaje.Text = "El código del producto ya existe";
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al guardar producto: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private static void AsegurarInventarioParaProducto(SqlConnection connection, SqlTransaction transaction, int idProducto, decimal stockMinimo, decimal? stockMaximo)
+    {
+        using var command = new SqlCommand(@"MERGE Inventario AS destino
+USING (
+    SELECT IdBodega FROM Bodega WHERE Activo = 1
+) AS origen
+ON destino.IdProducto = @producto AND destino.IdBodega = origen.IdBodega
+WHEN MATCHED THEN
+    UPDATE SET StockMinimo = @stockMinimo,
+               StockMaximo = @stockMaximo,
+WHEN NOT MATCHED THEN
+    INSERT (IdProducto, IdBodega, StockActual, StockReservado, StockMinimo, StockMaximo)
+    VALUES (@producto, origen.IdBodega, 0, 0, @stockMinimo, @stockMaximo);", connection, transaction);
+        command.Parameters.AddWithValue("@producto", idProducto);
+        command.Parameters.AddWithValue("@stockMinimo", stockMinimo);
+        command.Parameters.AddWithValue("@stockMaximo", (object?)stockMaximo ?? DBNull.Value);
+        command.ExecuteNonQuery();
+    }
+
+    private void CambiarEstado(bool activar)
+    {
+        if (_idSeleccionado == null)
+        {
+            MessageBox.Show("Seleccione un producto", "Atención", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var accion = activar ? "activar" : "desactivar";
+        if (MessageBox.Show($"¿Desea {accion} el producto seleccionado?", "Confirmación", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+        {
+            return;
+        }
+
+        try
+        {
+            Db.Execute("UPDATE Producto SET Activo = @activo WHERE IdProducto = @id", p =>
+            {
+                p.AddWithValue("@activo", activar);
+                p.AddWithValue("@id", _idSeleccionado);
+            });
+
+            CargarProductos();
+            LimpiarFormulario();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al actualizar producto: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CrearCategoria()
+    {
+        var nombre = SolicitarTexto("Nueva categoría", "Nombre de la categoría");
+        if (string.IsNullOrWhiteSpace(nombre))
+        {
+            return;
+        }
+
+        var descripcion = SolicitarTexto("Descripción opcional", "Descripción", permitirVacío: true);
+
+        try
+        {
+            using var connection = Db.GetConnection();
+            connection.Open();
+            using var command = new SqlCommand(@"INSERT INTO CategoriaProducto (Nombre, Descripcion, Activo)
+VALUES (@nombre, @descripcion, 1);
+SELECT CAST(SCOPE_IDENTITY() AS INT);", connection);
+            command.Parameters.AddWithValue("@nombre", nombre.Trim());
+            command.Parameters.AddWithValue("@descripcion", string.IsNullOrWhiteSpace(descripcion) ? DBNull.Value : descripcion.Trim());
+            var id = command.ExecuteScalar();
+            if (id != null)
+            {
+                CargarCategorias();
+                _cmbCategoria.SelectedValue = Convert.ToInt32(id);
+            }
+        }
+        catch (SqlException ex) when (ex.Number is 2601 or 2627)
+        {
+            MessageBox.Show("Ya existe una categoría con ese nombre", "Advertencia", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al crear categoría: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private static string? SolicitarTexto(string titulo, string etiqueta, bool permitirVacío = false)
+    {
+        using var dialogo = new Form
+        {
+            Text = titulo,
+            StartPosition = FormStartPosition.CenterParent,
+            Size = new Size(420, 200),
+            MinimizeBox = false,
+            MaximizeBox = false,
+            FormBorderStyle = FormBorderStyle.FixedDialog
+        };
+
+        UiTheme.ApplyMinimalStyle(dialogo);
+        dialogo.Padding = new Padding(24);
+
+        var label = new Label { Text = etiqueta, AutoSize = true, ForeColor = UiTheme.MutedTextColor };
+        var texto = new TextBox { Dock = DockStyle.Top, Margin = new Padding(0, 12, 0, 12) };
+        UiTheme.StyleTextInput(texto);
+
+        var btnAceptar = new Button { Text = "Aceptar", DialogResult = DialogResult.OK };
+        var btnCancelar = new Button { Text = "Cancelar", DialogResult = DialogResult.Cancel };
+        UiTheme.StylePrimaryButton(btnAceptar);
+        UiTheme.StyleSecondaryButton(btnCancelar);
+        btnAceptar.Margin = new Padding(0, 0, 8, 0);
+
+        var panelBotones = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Bottom,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false
+        };
+        panelBotones.Controls.Add(btnAceptar);
+        panelBotones.Controls.Add(btnCancelar);
+
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 3
+        };
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.Controls.Add(label, 0, 0);
+        layout.Controls.Add(texto, 0, 1);
+        layout.Controls.Add(panelBotones, 0, 2);
+
+        dialogo.Controls.Add(layout);
+        dialogo.AcceptButton = btnAceptar;
+        dialogo.CancelButton = btnCancelar;
+
+        return dialogo.ShowDialog() == DialogResult.OK
+            ? (permitirVacío ? texto.Text : texto.Text.Trim().Length == 0 ? null : texto.Text.Trim())
+            : null;
+    }
+}

--- a/ERP 2 evaluacion/RegistroForm.cs
+++ b/ERP 2 evaluacion/RegistroForm.cs
@@ -9,7 +9,7 @@ namespace ERP_2_evaluacion;
 
 public class RegistroForm : Form
 {
-    internal const string CodigoPerfilPorDefecto = "BASICO";
+    internal const string CodigoPerfilPorDefecto = "VENDEDOR";
 
     private readonly Label _lblTitulo = UiTheme.CreateTitleLabel("Crear una cuenta");
     private readonly Label _lblSubtitulo = new()
@@ -297,7 +297,7 @@ SELECT CAST(SCOPE_IDENTITY() AS INT);", connection);
                 if (resultado == null)
                 {
                     using var crearPerfil = new SqlCommand(
-                        "INSERT INTO Perfil (NombrePerfil, Codigo, Descripcion, Activo) VALUES ('Básico', @codigoPerfil, 'Perfil por defecto', 1);" +
+                        "INSERT INTO Perfil (NombrePerfil, Codigo, Descripcion, Activo) VALUES ('Vendedor', @codigoPerfil, 'Perfil por defecto de vendedores', 1);" +
                         "SELECT CAST(SCOPE_IDENTITY() AS INT);", connection, transaction);
                     crearPerfil.Parameters.AddWithValue("@codigoPerfil", codigoPerfil);
                     var nuevoId = crearPerfil.ExecuteScalar();

--- a/ERP 2 evaluacion/UiTheme.cs
+++ b/ERP 2 evaluacion/UiTheme.cs
@@ -18,6 +18,8 @@ public static class UiTheme
     public static readonly Color SecondaryButtonHoverColor = Color.FromArgb(218, 224, 236);
     public static readonly Color DangerColor = Color.FromArgb(218, 63, 60);
     public static readonly Color DangerColorHover = Color.FromArgb(185, 50, 48);
+    public static readonly Color SuccessColor = Color.FromArgb(46, 160, 67);
+    public static readonly Color SuccessColorHover = Color.FromArgb(35, 138, 55);
 
     public static readonly Font BaseFont = new("Segoe UI", 11F, FontStyle.Regular, GraphicsUnit.Point);
     public static readonly Font TitleFont = new("Segoe UI", 22F, FontStyle.Bold, GraphicsUnit.Point);
@@ -186,6 +188,15 @@ public static class UiTheme
         button.ForeColor = Color.White;
         button.FlatAppearance.MouseOverBackColor = DangerColorHover;
         button.FlatAppearance.BorderColor = DangerColor;
+    }
+
+    public static void StyleSuccessButton(Button button)
+    {
+        StyleBaseButton(button);
+        button.BackColor = SuccessColor;
+        button.ForeColor = Color.White;
+        button.FlatAppearance.MouseOverBackColor = SuccessColorHover;
+        button.FlatAppearance.BorderColor = SuccessColor;
     }
 
     private static void StyleBaseButton(Button button)

--- a/ERP 2 evaluacion/VentasForm.cs
+++ b/ERP 2 evaluacion/VentasForm.cs
@@ -1,0 +1,615 @@
+using Microsoft.Data.SqlClient;
+using System;
+using System.Data;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace ERP_2_evaluacion;
+
+public class VentasForm : Form
+{
+    private readonly int _idUsuario;
+
+    private readonly ComboBox _cmbCliente = new();
+    private readonly ComboBox _cmbBodega = new();
+    private readonly DateTimePicker _dtpFecha = new()
+    {
+        Format = DateTimePickerFormat.Custom,
+        CustomFormat = "dd/MM/yyyy HH:mm",
+        Value = DateTime.Now,
+        Dock = DockStyle.Fill
+    };
+    private readonly TextBox _txtObservaciones = new() { PlaceholderText = "Observaciones", Multiline = true, Height = 80 };
+
+    private readonly ComboBox _cmbProducto = new();
+    private readonly NumericUpDown _nudCantidad = new()
+    {
+        DecimalPlaces = 2,
+        Minimum = 0.01M,
+        Maximum = 1_000_000,
+        Increment = 1,
+        Value = 1
+    };
+    private readonly NumericUpDown _nudPrecio = new()
+    {
+        DecimalPlaces = 2,
+        Minimum = 0.01M,
+        Maximum = 1_000_000,
+        Increment = 1
+    };
+    private readonly NumericUpDown _nudDescuento = new()
+    {
+        DecimalPlaces = 2,
+        Minimum = 0M,
+        Maximum = 1_000_000,
+        Increment = 1
+    };
+
+    private readonly Button _btnAgregar = new() { Text = "Agregar" };
+    private readonly Button _btnQuitar = new() { Text = "Quitar" };
+    private readonly Button _btnGuardar = new() { Text = "Registrar venta" };
+
+    private readonly DataGridView _gridDetalles = new()
+    {
+        Dock = DockStyle.Fill,
+        ReadOnly = true,
+        SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+        MultiSelect = false,
+        AutoGenerateColumns = false
+    };
+
+    private readonly Label _lblTotales = new() { AutoSize = true, ForeColor = UiTheme.TextColor, Font = UiTheme.SectionTitleFont };
+    private readonly Label _lblMensaje = new() { AutoSize = true, ForeColor = UiTheme.DangerColor };
+
+    private DataTable? _productos;
+    private DataTable _detalles = new();
+
+    public VentasForm(int idUsuario)
+    {
+        _idUsuario = idUsuario;
+
+        Text = "Ventas";
+        StartPosition = FormStartPosition.CenterParent;
+        Size = new Size(1320, 880);
+        MinimumSize = new Size(1180, 760);
+
+        UiTheme.ApplyMinimalStyle(this);
+
+        UiTheme.StyleComboBox(_cmbCliente);
+        UiTheme.StyleComboBox(_cmbBodega);
+        UiTheme.StyleComboBox(_cmbProducto);
+        _cmbProducto.Dock = DockStyle.Fill;
+        UiTheme.StyleTextInput(_txtObservaciones);
+        StyleNumericUpDown(_nudCantidad);
+        StyleNumericUpDown(_nudPrecio);
+        StyleNumericUpDown(_nudDescuento);
+
+        UiTheme.StyleSecondaryButton(_btnAgregar);
+        UiTheme.StyleDangerButton(_btnQuitar);
+        UiTheme.StylePrimaryButton(_btnGuardar);
+        _btnAgregar.Margin = new Padding(12, 0, 0, 0);
+        _btnQuitar.Margin = new Padding(12, 0, 0, 0);
+        _btnGuardar.Margin = new Padding(0, 24, 0, 0);
+
+        ConfigurarGrid();
+        InicializarDetalles();
+
+        var layout = CrearLayout();
+        Controls.Add(layout);
+
+        Load += VentasForm_Load;
+        _cmbProducto.SelectedIndexChanged += (_, _) => ActualizarPrecioProducto();
+        _btnAgregar.Click += (_, _) => AgregarDetalle();
+        _btnQuitar.Click += (_, _) => QuitarDetalle();
+        _btnGuardar.Click += (_, _) => GuardarVenta();
+        _gridDetalles.SelectionChanged += (_, _) => _btnQuitar.Enabled = _gridDetalles.SelectedRows.Count > 0;
+        _btnQuitar.Enabled = false;
+    }
+
+    private void VentasForm_Load(object? sender, EventArgs e)
+    {
+        CargarClientes();
+        CargarBodegas();
+        CargarProductos();
+        ActualizarTotales();
+    }
+
+    private void ConfigurarGrid()
+    {
+        _gridDetalles.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Id", DataPropertyName = "IdProducto", Width = 60 });
+        _gridDetalles.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Código", DataPropertyName = "Codigo", Width = 120 });
+        _gridDetalles.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Producto", DataPropertyName = "Producto", AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill });
+        _gridDetalles.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Cantidad", DataPropertyName = "Cantidad", Width = 120, DefaultCellStyle = new DataGridViewCellStyle { Format = "N2" } });
+        _gridDetalles.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Precio", DataPropertyName = "Precio", Width = 120, DefaultCellStyle = new DataGridViewCellStyle { Format = "C2" } });
+        _gridDetalles.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Descuento", DataPropertyName = "Descuento", Width = 120, DefaultCellStyle = new DataGridViewCellStyle { Format = "C2" } });
+        _gridDetalles.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Total", DataPropertyName = "Total", Width = 140, DefaultCellStyle = new DataGridViewCellStyle { Format = "C2" } });
+    }
+
+    private void InicializarDetalles()
+    {
+        if (_detalles != null)
+        {
+            _detalles.RowChanged -= Detalles_RowChanged;
+            _detalles.RowDeleted -= Detalles_RowChanged;
+        }
+
+        _detalles = new DataTable();
+        _detalles.Columns.Add("IdProducto", typeof(int));
+        _detalles.Columns.Add("Codigo", typeof(string));
+        _detalles.Columns.Add("Producto", typeof(string));
+        _detalles.Columns.Add("Cantidad", typeof(decimal));
+        _detalles.Columns.Add("Precio", typeof(decimal));
+        _detalles.Columns.Add("Descuento", typeof(decimal));
+        _detalles.Columns.Add("Total", typeof(decimal));
+        _detalles.RowChanged += Detalles_RowChanged;
+        _detalles.RowDeleted += Detalles_RowChanged;
+        _gridDetalles.DataSource = _detalles;
+    }
+
+    private void Detalles_RowChanged(object? sender, DataRowChangeEventArgs e) => ActualizarTotales();
+
+    private void StyleNumericUpDown(NumericUpDown control)
+    {
+        control.BorderStyle = BorderStyle.FixedSingle;
+        control.Font = UiTheme.BaseFont;
+        control.Margin = new Padding(0, 6, 0, 16);
+        control.MinimumSize = new Size(160, 36);
+        control.MaximumSize = new Size(260, 44);
+        control.Dock = DockStyle.Fill;
+    }
+
+    private Control CrearLayout()
+    {
+        var root = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 1
+        };
+        root.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+
+        var card = UiTheme.CreateCardPanel();
+        card.Padding = new Padding(32, 32, 32, 24);
+
+        var content = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 7,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink
+        };
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        content.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+        var encabezado = new TableLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            ColumnCount = 3,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink
+        };
+        encabezado.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33));
+        encabezado.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33));
+        encabezado.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 34));
+
+        encabezado.Controls.Add(UiTheme.CreateSectionLabel("Bodega"), 0, 0);
+        encabezado.Controls.Add(UiTheme.CreateSectionLabel("Cliente"), 1, 0);
+        encabezado.Controls.Add(UiTheme.CreateSectionLabel("Fecha"), 2, 0);
+        encabezado.Controls.Add(_cmbBodega, 0, 1);
+        encabezado.Controls.Add(_cmbCliente, 1, 1);
+        encabezado.Controls.Add(_dtpFecha, 2, 1);
+
+        var observacionesLayout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            ColumnCount = 1,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink
+        };
+        observacionesLayout.Controls.Add(new Label { Text = "Observaciones", AutoSize = true, ForeColor = UiTheme.MutedTextColor, Margin = new Padding(0, 16, 0, 0) }, 0, 0);
+        observacionesLayout.Controls.Add(_txtObservaciones, 0, 1);
+
+        var agregarLayout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            ColumnCount = 5,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Margin = new Padding(0, 16, 0, 0)
+        };
+        agregarLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 30));
+        agregarLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20));
+        agregarLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20));
+        agregarLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 15));
+        agregarLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 15));
+
+        agregarLayout.Controls.Add(new Label { Text = "Producto", AutoSize = true, ForeColor = UiTheme.MutedTextColor }, 0, 0);
+        agregarLayout.Controls.Add(new Label { Text = "Cantidad", AutoSize = true, ForeColor = UiTheme.MutedTextColor }, 1, 0);
+        agregarLayout.Controls.Add(new Label { Text = "Precio", AutoSize = true, ForeColor = UiTheme.MutedTextColor }, 2, 0);
+        agregarLayout.Controls.Add(new Label { Text = "Descuento", AutoSize = true, ForeColor = UiTheme.MutedTextColor }, 3, 0);
+        agregarLayout.Controls.Add(new Label(), 4, 0);
+
+        agregarLayout.Controls.Add(_cmbProducto, 0, 1);
+        agregarLayout.Controls.Add(_nudCantidad, 1, 1);
+        agregarLayout.Controls.Add(_nudPrecio, 2, 1);
+        agregarLayout.Controls.Add(_nudDescuento, 3, 1);
+
+        var accionesDetalle = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.LeftToRight,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false,
+            Margin = new Padding(0, 8, 0, 0)
+        };
+        accionesDetalle.Controls.Add(_btnAgregar);
+        accionesDetalle.Controls.Add(_btnQuitar);
+        agregarLayout.Controls.Add(accionesDetalle, 4, 1);
+
+        _lblMensaje.Margin = new Padding(0, 16, 0, 0);
+        _gridDetalles.Margin = new Padding(0, 16, 0, 0);
+        _lblTotales.Margin = new Padding(0, 16, 0, 0);
+
+        content.Controls.Add(encabezado, 0, 0);
+        content.Controls.Add(observacionesLayout, 0, 1);
+        content.Controls.Add(agregarLayout, 0, 2);
+        content.Controls.Add(_gridDetalles, 0, 3);
+        content.Controls.Add(_lblTotales, 0, 4);
+        content.Controls.Add(_lblMensaje, 0, 5);
+
+        card.Controls.Add(content);
+
+        var footer = new FlowLayoutPanel
+        {
+            FlowDirection = FlowDirection.RightToLeft,
+            Dock = DockStyle.Bottom,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            WrapContents = false,
+            Margin = new Padding(0, 24, 0, 0)
+        };
+        footer.Controls.Add(_btnGuardar);
+        content.Controls.Add(footer, 0, 6);
+
+        root.Controls.Add(card, 0, 0);
+
+        return root;
+    }
+
+    private void CargarClientes()
+    {
+        try
+        {
+            var clientes = Db.GetDataTable("SELECT IdCliente, NombreCompleto FROM Cliente WHERE Activo = 1 ORDER BY NombreCompleto");
+            _cmbCliente.DisplayMember = "NombreCompleto";
+            _cmbCliente.ValueMember = "IdCliente";
+            _cmbCliente.DataSource = clientes;
+            _cmbCliente.SelectedIndex = clientes.Rows.Count > 0 ? 0 : -1;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar clientes: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarBodegas()
+    {
+        try
+        {
+            var bodegas = Db.GetDataTable("SELECT IdBodega, Nombre FROM Bodega WHERE Activo = 1 ORDER BY Nombre");
+            _cmbBodega.DisplayMember = "Nombre";
+            _cmbBodega.ValueMember = "IdBodega";
+            _cmbBodega.DataSource = bodegas;
+            _cmbBodega.SelectedIndex = bodegas.Rows.Count > 0 ? 0 : -1;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar bodegas: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void CargarProductos()
+    {
+        try
+        {
+            _productos = Db.GetDataTable("SELECT IdProducto, Codigo, Nombre, PrecioVenta FROM Producto WHERE Activo = 1 ORDER BY Nombre");
+            _cmbProducto.DisplayMember = "Nombre";
+            _cmbProducto.ValueMember = "IdProducto";
+            _cmbProducto.DataSource = _productos;
+            if (_productos.Rows.Count > 0)
+            {
+                _cmbProducto.SelectedIndex = 0;
+                ActualizarPrecioProducto();
+            }
+            else
+            {
+                _cmbProducto.SelectedIndex = -1;
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al cargar productos: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void ActualizarPrecioProducto()
+    {
+        if (_cmbProducto.SelectedValue is not int idProducto || _productos == null)
+        {
+            return;
+        }
+
+        var fila = _productos.AsEnumerable().FirstOrDefault(r => r.Field<int>("IdProducto") == idProducto);
+        if (fila != null)
+        {
+            var precioVenta = fila.Field<decimal>("PrecioVenta");
+            _nudPrecio.Value = precioVenta > _nudPrecio.Maximum ? _nudPrecio.Maximum : precioVenta;
+        }
+    }
+
+    private void AgregarDetalle()
+    {
+        _lblMensaje.ForeColor = UiTheme.DangerColor;
+        _lblMensaje.Text = string.Empty;
+
+        if (_cmbProducto.SelectedValue is not int idProducto)
+        {
+            _lblMensaje.Text = "Seleccione un producto";
+            return;
+        }
+        if (_cmbBodega.SelectedValue is not int idBodega)
+        {
+            _lblMensaje.Text = "Seleccione una bodega";
+            return;
+        }
+
+        var cantidad = _nudCantidad.Value;
+        var precio = _nudPrecio.Value;
+        var descuento = _nudDescuento.Value;
+
+        if (cantidad <= 0)
+        {
+            _lblMensaje.Text = "La cantidad debe ser mayor que cero";
+            return;
+        }
+
+        if (precio <= 0)
+        {
+            _lblMensaje.Text = "El precio debe ser mayor que cero";
+            return;
+        }
+
+        try
+        {
+            var stockDisponible = ObtenerStockDisponible(idProducto, idBodega);
+            var cantidadExistente = _detalles.AsEnumerable()
+                .Where(r => r.Field<int>("IdProducto") == idProducto)
+                .Sum(r => r.Field<decimal>("Cantidad"));
+
+            if (cantidad + cantidadExistente > stockDisponible)
+            {
+                _lblMensaje.Text = "No hay suficiente stock disponible";
+                return;
+            }
+
+            var filaExistente = _detalles.AsEnumerable().FirstOrDefault(r => r.Field<int>("IdProducto") == idProducto);
+            if (filaExistente != null)
+            {
+                var nuevaCantidad = filaExistente.Field<decimal>("Cantidad") + cantidad;
+                var nuevoDescuento = filaExistente.Field<decimal>("Descuento") + descuento;
+                var totalActualizado = CalcularTotalLinea(nuevaCantidad, precio, nuevoDescuento);
+                if (totalActualizado < 0)
+                {
+                    _lblMensaje.Text = "El descuento supera el total de la línea";
+                    return;
+                }
+
+                filaExistente["Cantidad"] = nuevaCantidad;
+                filaExistente["Descuento"] = nuevoDescuento;
+                filaExistente["Precio"] = precio;
+                filaExistente["Total"] = totalActualizado;
+            }
+            else
+            {
+                var codigo = _productos?.AsEnumerable().First(r => r.Field<int>("IdProducto") == idProducto).Field<string>("Codigo");
+                var nombre = _cmbProducto.Text;
+                var total = CalcularTotalLinea(cantidad, precio, descuento);
+                if (total < 0)
+                {
+                    _lblMensaje.Text = "El descuento supera el total de la línea";
+                    return;
+                }
+
+                _detalles.Rows.Add(idProducto, codigo, nombre, cantidad, precio, descuento, total);
+            }
+
+            _lblMensaje.ForeColor = UiTheme.AccentColor;
+            _lblMensaje.Text = "Producto agregado";
+            _nudCantidad.Value = 1;
+            _nudDescuento.Value = 0;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al agregar producto: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void QuitarDetalle()
+    {
+        _lblMensaje.Text = string.Empty;
+        if (_gridDetalles.SelectedRows.Count == 0)
+        {
+            return;
+        }
+
+        if (_gridDetalles.SelectedRows[0].DataBoundItem is DataRowView fila)
+        {
+            _detalles.Rows.Remove(fila.Row);
+        }
+    }
+
+    private static decimal CalcularTotalLinea(decimal cantidad, decimal precio, decimal descuento) => (cantidad * precio) - descuento;
+
+    private decimal ObtenerStockDisponible(int idProducto, int idBodega)
+    {
+        var resultado = Db.Scalar("SELECT ISNULL(StockActual, 0) FROM Inventario WHERE IdProducto = @producto AND IdBodega = @bodega", p =>
+        {
+            p.AddWithValue("@producto", idProducto);
+            p.AddWithValue("@bodega", idBodega);
+        });
+        return resultado == null ? 0 : Convert.ToDecimal(resultado);
+    }
+
+    private void ActualizarTotales()
+    {
+        if (_detalles.Rows.Count == 0)
+        {
+            _lblTotales.Text = "Sin productos agregados";
+            return;
+        }
+
+        var subtotal = _detalles.AsEnumerable().Sum(r => CalcularTotalLinea(r.Field<decimal>("Cantidad"), r.Field<decimal>("Precio"), r.Field<decimal>("Descuento")));
+        var impuestos = 0m;
+        var total = subtotal + impuestos;
+        _lblTotales.Text = $"Subtotal: {subtotal.ToString("C2", CultureInfo.CurrentCulture)}    Total: {total.ToString("C2", CultureInfo.CurrentCulture)}";
+    }
+
+    private void GuardarVenta()
+    {
+        _lblMensaje.ForeColor = UiTheme.DangerColor;
+        _lblMensaje.Text = string.Empty;
+
+        if (_cmbBodega.SelectedValue is not int idBodega)
+        {
+            _lblMensaje.Text = "Seleccione una bodega";
+            return;
+        }
+
+        if (_detalles.Rows.Count == 0)
+        {
+            _lblMensaje.Text = "Agregue al menos un producto";
+            return;
+        }
+
+        var clienteId = _cmbCliente.SelectedValue as int?;
+        var fecha = _dtpFecha.Value;
+        var observaciones = _txtObservaciones.Text.Trim();
+
+        var subtotal = _detalles.AsEnumerable().Sum(r => CalcularTotalLinea(r.Field<decimal>("Cantidad"), r.Field<decimal>("Precio"), r.Field<decimal>("Descuento")));
+        var impuestos = 0m;
+        var total = subtotal + impuestos;
+
+        try
+        {
+            using var connection = Db.GetConnection();
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+
+            var numero = GenerarNumeroVenta();
+            int idVenta;
+            using (var cmdVenta = new SqlCommand(@"INSERT INTO Venta (Numero, Fecha, IdUsuario, IdCliente, IdBodega, Subtotal, Impuestos, Total, Observaciones)
+VALUES (@numero, @fecha, @usuario, @cliente, @bodega, @subtotal, @impuestos, @total, @observaciones);
+SELECT CAST(SCOPE_IDENTITY() AS INT);", connection, transaction))
+            {
+                cmdVenta.Parameters.AddWithValue("@numero", numero);
+                cmdVenta.Parameters.AddWithValue("@fecha", fecha);
+                cmdVenta.Parameters.AddWithValue("@usuario", _idUsuario);
+                cmdVenta.Parameters.AddWithValue("@cliente", clienteId.HasValue ? clienteId.Value : DBNull.Value);
+                cmdVenta.Parameters.AddWithValue("@bodega", idBodega);
+                cmdVenta.Parameters.AddWithValue("@subtotal", subtotal);
+                cmdVenta.Parameters.AddWithValue("@impuestos", impuestos);
+                cmdVenta.Parameters.AddWithValue("@total", total);
+                cmdVenta.Parameters.AddWithValue("@observaciones", string.IsNullOrWhiteSpace(observaciones) ? DBNull.Value : observaciones);
+
+                var resultado = cmdVenta.ExecuteScalar();
+                if (resultado == null)
+                {
+                    throw new InvalidOperationException("No se pudo crear la venta");
+                }
+
+                idVenta = Convert.ToInt32(resultado);
+            }
+
+            foreach (DataRow row in _detalles.Rows)
+            {
+                var idProducto = row.Field<int>("IdProducto");
+                var cantidad = row.Field<decimal>("Cantidad");
+                var precio = row.Field<decimal>("Precio");
+                var descuento = row.Field<decimal>("Descuento");
+                var totalLinea = CalcularTotalLinea(cantidad, precio, descuento);
+
+                int idInventario;
+                decimal stockActual;
+                using (var cmdInventario = new SqlCommand("SELECT IdInventario, StockActual FROM Inventario WHERE IdProducto = @producto AND IdBodega = @bodega", connection, transaction))
+                {
+                    cmdInventario.Parameters.AddWithValue("@producto", idProducto);
+                    cmdInventario.Parameters.AddWithValue("@bodega", idBodega);
+                    using var reader = cmdInventario.ExecuteReader();
+                    if (!reader.Read())
+                    {
+                        throw new InvalidOperationException("No existe inventario para el producto seleccionado en la bodega");
+                    }
+                    idInventario = reader.GetInt32(0);
+                    stockActual = reader.GetDecimal(1);
+                }
+
+                if (stockActual < cantidad)
+                {
+                    throw new InvalidOperationException($"Stock insuficiente para el producto {row["Producto"]}");
+                }
+
+                using (var cmdActualizar = new SqlCommand("UPDATE Inventario SET StockActual = StockActual - @cantidad, FechaActualizacion = GETDATE() WHERE IdInventario = @inventario", connection, transaction))
+                {
+                    cmdActualizar.Parameters.AddWithValue("@cantidad", cantidad);
+                    cmdActualizar.Parameters.AddWithValue("@inventario", idInventario);
+                    cmdActualizar.ExecuteNonQuery();
+                }
+
+                using (var cmdMovimiento = new SqlCommand(@"INSERT INTO MovimientoInventario (IdInventario, TipoMovimiento, Cantidad, Motivo, Referencia, IdUsuario)
+VALUES (@inventario, 'VENTA', @cantidad, @motivo, @referencia, @usuario);", connection, transaction))
+                {
+                    cmdMovimiento.Parameters.AddWithValue("@inventario", idInventario);
+                    cmdMovimiento.Parameters.AddWithValue("@cantidad", cantidad);
+                    cmdMovimiento.Parameters.AddWithValue("@motivo", $"Venta {numero}");
+                    cmdMovimiento.Parameters.AddWithValue("@referencia", numero);
+                    cmdMovimiento.Parameters.AddWithValue("@usuario", _idUsuario);
+                    cmdMovimiento.ExecuteNonQuery();
+                }
+
+                using (var cmdDetalle = new SqlCommand(@"INSERT INTO VentaDetalle (IdVenta, IdProducto, Cantidad, PrecioUnitario, Descuento, Total)
+VALUES (@venta, @producto, @cantidad, @precio, @descuento, @total);", connection, transaction))
+                {
+                    cmdDetalle.Parameters.AddWithValue("@venta", idVenta);
+                    cmdDetalle.Parameters.AddWithValue("@producto", idProducto);
+                    cmdDetalle.Parameters.AddWithValue("@cantidad", cantidad);
+                    cmdDetalle.Parameters.AddWithValue("@precio", precio);
+                    cmdDetalle.Parameters.AddWithValue("@descuento", descuento);
+                    cmdDetalle.Parameters.AddWithValue("@total", totalLinea);
+                    cmdDetalle.ExecuteNonQuery();
+                }
+            }
+
+            transaction.Commit();
+            MessageBox.Show("Venta registrada correctamente", "Éxito", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            InicializarDetalles();
+            ActualizarTotales();
+            _txtObservaciones.Clear();
+            _lblMensaje.ForeColor = UiTheme.AccentColor;
+            _lblMensaje.Text = $"Venta {numero} registrada correctamente.";
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error al registrar la venta: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private static string GenerarNumeroVenta() => $"V{DateTime.Now:yyyyMMddHHmmssfff}";
+}

--- a/Seed.sql
+++ b/Seed.sql
@@ -36,6 +36,36 @@ BEGIN
     VALUES ('ACCESOS', 'Accesos', 'AccesosForm', @IdPantallaPrincipal, 3, 'SEED');
 END;
 
+IF NOT EXISTS (SELECT 1 FROM dbo.Pantalla WHERE Codigo = 'BODEGAS')
+BEGIN
+    INSERT INTO dbo.Pantalla (Codigo, NombrePantalla, Ruta, IdPadre, Orden, CreadoPor)
+    VALUES ('BODEGAS', 'Bodegas', 'BodegasForm', @IdPantallaPrincipal, 4, 'SEED');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Pantalla WHERE Codigo = 'PRODUCTOS')
+BEGIN
+    INSERT INTO dbo.Pantalla (Codigo, NombrePantalla, Ruta, IdPadre, Orden, CreadoPor)
+    VALUES ('PRODUCTOS', 'Productos', 'ProductosForm', @IdPantallaPrincipal, 5, 'SEED');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Pantalla WHERE Codigo = 'INVENTARIO')
+BEGIN
+    INSERT INTO dbo.Pantalla (Codigo, NombrePantalla, Ruta, IdPadre, Orden, CreadoPor)
+    VALUES ('INVENTARIO', 'Inventario', 'InventarioForm', @IdPantallaPrincipal, 6, 'SEED');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Pantalla WHERE Codigo = 'CLIENTES')
+BEGIN
+    INSERT INTO dbo.Pantalla (Codigo, NombrePantalla, Ruta, IdPadre, Orden, CreadoPor)
+    VALUES ('CLIENTES', 'Clientes', 'ClientesForm', @IdPantallaPrincipal, 7, 'SEED');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Pantalla WHERE Codigo = 'VENTAS')
+BEGIN
+    INSERT INTO dbo.Pantalla (Codigo, NombrePantalla, Ruta, IdPadre, Orden, CreadoPor)
+    VALUES ('VENTAS', 'Ventas', 'VentasForm', @IdPantallaPrincipal, 8, 'SEED');
+END;
+
 -- Perfiles básicos de la aplicación
 IF NOT EXISTS (SELECT 1 FROM dbo.Perfil WHERE Codigo = 'SUPERADMIN')
 BEGIN
@@ -49,13 +79,22 @@ BEGIN
     VALUES ('Administrador', 'ADMIN', 'Administrador funcional con permisos ampliados', 1);
 END;
 
-IF NOT EXISTS (SELECT 1 FROM dbo.Perfil WHERE Codigo = 'BASICO')
+IF NOT EXISTS (SELECT 1 FROM dbo.Perfil WHERE Codigo = 'BODEGUERO')
 BEGIN
     INSERT INTO dbo.Perfil (NombrePerfil, Codigo, Descripcion, Activo)
-    VALUES ('Básico', 'BASICO', 'Perfil por defecto para nuevos usuarios', 1);
+    VALUES ('Encargado de Bodega', 'BODEGUERO', 'Gestiona bodegas, productos e inventario', 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Perfil WHERE Codigo = 'VENDEDOR')
+BEGIN
+    INSERT INTO dbo.Perfil (NombrePerfil, Codigo, Descripcion, Activo)
+    VALUES ('Vendedor', 'VENDEDOR', 'Registra ventas y gestiona clientes', 1);
 END;
 
 DECLARE @IdPerfilSuper INT = (SELECT IdPerfil FROM dbo.Perfil WHERE Codigo = 'SUPERADMIN');
+DECLARE @IdPerfilAdmin INT = (SELECT IdPerfil FROM dbo.Perfil WHERE Codigo = 'ADMIN');
+DECLARE @IdPerfilBodeguero INT = (SELECT IdPerfil FROM dbo.Perfil WHERE Codigo = 'BODEGUERO');
+DECLARE @IdPerfilVendedor INT = (SELECT IdPerfil FROM dbo.Perfil WHERE Codigo = 'VENDEDOR');
 
 -- Crear o actualizar el super usuario por defecto
 DECLARE @IdUsuarioAdmin INT;
@@ -116,3 +155,207 @@ WHEN NOT MATCHED THEN
     INSERT (IdPerfil, IdPantalla, PuedeVer, PuedeCrear, PuedeEditar, PuedeEliminar, PuedeExportar, Activo, FechaOtorgado, OtorgadoPor)
     VALUES (origen.IdPerfil, origen.IdPantalla, 1, 1, 1, 1, 1, 1, @Ahora, 'SEED');
 GO
+
+IF @IdPerfilAdmin IS NOT NULL
+BEGIN
+    DECLARE @PermisosAdmin TABLE (Codigo NVARCHAR(50), PuedeVer BIT, PuedeCrear BIT, PuedeEditar BIT, PuedeEliminar BIT, PuedeExportar BIT);
+    INSERT INTO @PermisosAdmin VALUES
+        ('PRINCIPAL', 1, 0, 0, 0, 0),
+        ('USUARIOS', 1, 1, 1, 1, 1),
+        ('PERFILES', 1, 1, 1, 1, 1),
+        ('ACCESOS', 1, 1, 1, 1, 1),
+        ('BODEGAS', 1, 1, 1, 1, 1),
+        ('PRODUCTOS', 1, 1, 1, 1, 1),
+        ('INVENTARIO', 1, 1, 1, 1, 1),
+        ('CLIENTES', 1, 1, 1, 1, 1),
+        ('VENTAS', 1, 1, 1, 1, 1);
+
+    MERGE dbo.PerfilPantallaAcceso AS destino
+    USING (
+        SELECT @IdPerfilAdmin AS IdPerfil,
+               p.IdPantalla,
+               r.PuedeVer,
+               r.PuedeCrear,
+               r.PuedeEditar,
+               r.PuedeEliminar,
+               r.PuedeExportar
+        FROM @PermisosAdmin r
+        JOIN dbo.Pantalla p ON p.Codigo = r.Codigo
+    ) AS origen
+    ON destino.IdPerfil = origen.IdPerfil AND destino.IdPantalla = origen.IdPantalla
+    WHEN MATCHED THEN
+        UPDATE SET PuedeVer = origen.PuedeVer,
+                   PuedeCrear = origen.PuedeCrear,
+                   PuedeEditar = origen.PuedeEditar,
+                   PuedeEliminar = origen.PuedeEliminar,
+                   PuedeExportar = origen.PuedeExportar,
+                   Activo = 1,
+                   FechaOtorgado = @Ahora,
+                   OtorgadoPor = 'SEED'
+    WHEN NOT MATCHED THEN
+        INSERT (IdPerfil, IdPantalla, PuedeVer, PuedeCrear, PuedeEditar, PuedeEliminar, PuedeExportar, Activo, FechaOtorgado, OtorgadoPor)
+        VALUES (origen.IdPerfil, origen.IdPantalla, origen.PuedeVer, origen.PuedeCrear, origen.PuedeEditar, origen.PuedeEliminar, origen.PuedeExportar, 1, @Ahora, 'SEED');
+END;
+
+IF @IdPerfilBodeguero IS NOT NULL
+BEGIN
+    DECLARE @PermisosBodeguero TABLE (Codigo NVARCHAR(50), PuedeVer BIT, PuedeCrear BIT, PuedeEditar BIT, PuedeEliminar BIT, PuedeExportar BIT);
+    INSERT INTO @PermisosBodeguero VALUES
+        ('PRINCIPAL', 1, 0, 0, 0, 0),
+        ('BODEGAS', 1, 1, 1, 1, 1),
+        ('PRODUCTOS', 1, 1, 1, 1, 1),
+        ('INVENTARIO', 1, 1, 1, 1, 1);
+
+    MERGE dbo.PerfilPantallaAcceso AS destino
+    USING (
+        SELECT @IdPerfilBodeguero AS IdPerfil,
+               p.IdPantalla,
+               r.PuedeVer,
+               r.PuedeCrear,
+               r.PuedeEditar,
+               r.PuedeEliminar,
+               r.PuedeExportar
+        FROM @PermisosBodeguero r
+        JOIN dbo.Pantalla p ON p.Codigo = r.Codigo
+    ) AS origen
+    ON destino.IdPerfil = origen.IdPerfil AND destino.IdPantalla = origen.IdPantalla
+    WHEN MATCHED THEN
+        UPDATE SET PuedeVer = origen.PuedeVer,
+                   PuedeCrear = origen.PuedeCrear,
+                   PuedeEditar = origen.PuedeEditar,
+                   PuedeEliminar = origen.PuedeEliminar,
+                   PuedeExportar = origen.PuedeExportar,
+                   Activo = 1,
+                   FechaOtorgado = @Ahora,
+                   OtorgadoPor = 'SEED'
+    WHEN NOT MATCHED THEN
+        INSERT (IdPerfil, IdPantalla, PuedeVer, PuedeCrear, PuedeEditar, PuedeEliminar, PuedeExportar, Activo, FechaOtorgado, OtorgadoPor)
+        VALUES (origen.IdPerfil, origen.IdPantalla, origen.PuedeVer, origen.PuedeCrear, origen.PuedeEditar, origen.PuedeEliminar, origen.PuedeExportar, 1, @Ahora, 'SEED');
+END;
+
+IF @IdPerfilVendedor IS NOT NULL
+BEGIN
+    DECLARE @PermisosVendedor TABLE (Codigo NVARCHAR(50), PuedeVer BIT, PuedeCrear BIT, PuedeEditar BIT, PuedeEliminar BIT, PuedeExportar BIT);
+    INSERT INTO @PermisosVendedor VALUES
+        ('PRINCIPAL', 1, 0, 0, 0, 0),
+        ('CLIENTES', 1, 1, 1, 0, 1),
+        ('VENTAS', 1, 1, 0, 0, 1);
+
+    MERGE dbo.PerfilPantallaAcceso AS destino
+    USING (
+        SELECT @IdPerfilVendedor AS IdPerfil,
+               p.IdPantalla,
+               r.PuedeVer,
+               r.PuedeCrear,
+               r.PuedeEditar,
+               r.PuedeEliminar,
+               r.PuedeExportar
+        FROM @PermisosVendedor r
+        JOIN dbo.Pantalla p ON p.Codigo = r.Codigo
+    ) AS origen
+    ON destino.IdPerfil = origen.IdPerfil AND destino.IdPantalla = origen.IdPantalla
+    WHEN MATCHED THEN
+        UPDATE SET PuedeVer = origen.PuedeVer,
+                   PuedeCrear = origen.PuedeCrear,
+                   PuedeEditar = origen.PuedeEditar,
+                   PuedeEliminar = origen.PuedeEliminar,
+                   PuedeExportar = origen.PuedeExportar,
+                   Activo = 1,
+                   FechaOtorgado = @Ahora,
+                   OtorgadoPor = 'SEED'
+    WHEN NOT MATCHED THEN
+        INSERT (IdPerfil, IdPantalla, PuedeVer, PuedeCrear, PuedeEditar, PuedeEliminar, PuedeExportar, Activo, FechaOtorgado, OtorgadoPor)
+        VALUES (origen.IdPerfil, origen.IdPantalla, origen.PuedeVer, origen.PuedeCrear, origen.PuedeEditar, origen.PuedeEliminar, origen.PuedeExportar, 1, @Ahora, 'SEED');
+END;
+
+IF EXISTS (SELECT 1 FROM dbo.Perfil WHERE Codigo = 'BASICO')
+BEGIN
+    UPDATE dbo.Perfil SET Activo = 0 WHERE Codigo = 'BASICO';
+END;
+
+-- Datos base para catálogos comerciales
+IF NOT EXISTS (SELECT 1 FROM dbo.Bodega WHERE Codigo = 'BOD-PRINC')
+BEGIN
+    INSERT INTO dbo.Bodega (Codigo, Nombre, Ubicacion, Encargado, Descripcion)
+    VALUES ('BOD-PRINC', 'Bodega Principal', 'Casa matriz', 'Encargado General', 'Bodega principal del negocio');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Bodega WHERE Codigo = 'BOD-SEC')
+BEGIN
+    INSERT INTO dbo.Bodega (Codigo, Nombre, Ubicacion, Encargado, Descripcion)
+    VALUES ('BOD-SEC', 'Bodega Secundaria', 'Sucursal centro', 'Encargado Sucursal', 'Bodega para despacho regional');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.CategoriaProducto WHERE Nombre = 'General')
+BEGIN
+    INSERT INTO dbo.CategoriaProducto (Nombre, Descripcion)
+    VALUES ('General', 'Productos generales de comercio');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.CategoriaProducto WHERE Nombre = 'Tecnología')
+BEGIN
+    INSERT INTO dbo.CategoriaProducto (Nombre, Descripcion)
+    VALUES ('Tecnología', 'Equipos y dispositivos electrónicos');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Producto WHERE Codigo = 'P-0001')
+BEGIN
+    DECLARE @IdCategoriaGeneral INT = (SELECT IdCategoria FROM dbo.CategoriaProducto WHERE Nombre = 'General');
+    INSERT INTO dbo.Producto (Codigo, Nombre, Descripcion, IdCategoria, PrecioCosto, PrecioVenta, StockMinimo, StockMaximo)
+    VALUES ('P-0001', 'Producto Genérico', 'Producto de ejemplo para demostración', @IdCategoriaGeneral, 10.00, 18.00, 5, 500);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Producto WHERE Codigo = 'P-0002')
+BEGIN
+    DECLARE @IdCategoriaTec INT = (SELECT IdCategoria FROM dbo.CategoriaProducto WHERE Nombre = 'Tecnología');
+    INSERT INTO dbo.Producto (Codigo, Nombre, Descripcion, IdCategoria, PrecioCosto, PrecioVenta, StockMinimo, StockMaximo)
+    VALUES ('P-0002', 'Dispositivo Inteligente', 'Equipo tecnológico para ventas minoristas', @IdCategoriaTec, 180.00, 250.00, 2, 120);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Cliente WHERE Identificacion = 'CLI-0001')
+BEGIN
+    INSERT INTO dbo.Cliente (NombreCompleto, Identificacion, TipoDocumento, Correo, Telefono, Direccion)
+    VALUES ('Cliente Mostrador', 'CLI-0001', 'RNC', 'cliente@comercio.local', '809-555-1000', 'Dirección comercial principal');
+END;
+
+IF NOT EXISTS (SELECT 1 FROM dbo.Cliente WHERE Identificacion = 'CLI-0002')
+BEGIN
+    INSERT INTO dbo.Cliente (NombreCompleto, Identificacion, TipoDocumento, Correo, Telefono, Direccion)
+    VALUES ('Compañía Corporativa', 'CLI-0002', 'RNC', 'ventas@clienteempresarial.local', '809-555-2000', 'Parque industrial');
+END;
+
+-- Asegurar inventario base para productos de ejemplo
+DECLARE @BodegaPrincipal INT = (SELECT IdBodega FROM dbo.Bodega WHERE Codigo = 'BOD-PRINC');
+DECLARE @BodegaSecundaria INT = (SELECT IdBodega FROM dbo.Bodega WHERE Codigo = 'BOD-SEC');
+
+IF @BodegaPrincipal IS NOT NULL
+BEGIN
+    MERGE dbo.Inventario AS destino
+    USING (
+        SELECT p.IdProducto, @BodegaPrincipal AS IdBodega, Cantidad = CASE p.Codigo WHEN 'P-0001' THEN 150 WHEN 'P-0002' THEN 25 ELSE 0 END
+        FROM dbo.Producto p
+    ) AS origen
+    ON destino.IdProducto = origen.IdProducto AND destino.IdBodega = origen.IdBodega
+    WHEN MATCHED THEN
+        UPDATE SET StockActual = CASE WHEN origen.Cantidad > 0 THEN origen.Cantidad ELSE destino.StockActual END,
+                   FechaActualizacion = @Ahora
+    WHEN NOT MATCHED THEN
+        INSERT (IdProducto, IdBodega, StockActual, StockMinimo, StockMaximo)
+        VALUES (origen.IdProducto, origen.IdBodega, origen.Cantidad, 0, NULL);
+END;
+
+IF @BodegaSecundaria IS NOT NULL
+BEGIN
+    MERGE dbo.Inventario AS destino
+    USING (
+        SELECT p.IdProducto, @BodegaSecundaria AS IdBodega, Cantidad = CASE p.Codigo WHEN 'P-0001' THEN 80 WHEN 'P-0002' THEN 10 ELSE 0 END
+        FROM dbo.Producto p
+    ) AS origen
+    ON destino.IdProducto = origen.IdProducto AND destino.IdBodega = origen.IdBodega
+    WHEN MATCHED THEN
+        UPDATE SET StockActual = CASE WHEN origen.Cantidad > 0 THEN origen.Cantidad ELSE destino.StockActual END,
+                   FechaActualizacion = @Ahora
+    WHEN NOT MATCHED THEN
+        INSERT (IdProducto, IdBodega, StockActual, StockMinimo, StockMaximo)
+        VALUES (origen.IdProducto, origen.IdBodega, origen.Cantidad, 0, NULL);
+END;


### PR DESCRIPTION
## Summary
- expand the database schema and seed data to include products, warehouses, inventory, clients, and sales modules with role-based permissions
- add WinForms screens for managing warehouses, products, inventory movements, clients, and sales registration
- update the main dashboard and registration workflow to surface the new modules and assign the vendor role by default

## Testing
- `dotnet build` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ff6226888332b88a650aebdb143a