### PR TITLE
Enable responsive layouts for ERP forms

### DIFF
--- a/ERP 2 evaluacion/AccesosForm.cs
+++ b/ERP 2 evaluacion/AccesosForm.cs
@@ -33,7 +33,6 @@ public class AccesosForm : Form
         Text = "Accesos";
         StartPosition = FormStartPosition.CenterParent;
         Size = new Size(1280, 840);
-        MinimumSize = new Size(1120, 720);
 
         UiTheme.ApplyMinimalStyle(this);
 

--- a/ERP 2 evaluacion/BodegasForm.cs
+++ b/ERP 2 evaluacion/BodegasForm.cs
@@ -38,7 +38,6 @@ public class BodegasForm : Form
         Text = "Bodegas";
         StartPosition = FormStartPosition.CenterParent;
         Size = new Size(1200, 780);
-        MinimumSize = new Size(1024, 680);
 
         UiTheme.ApplyMinimalStyle(this);
 

--- a/ERP 2 evaluacion/ClientesForm.cs
+++ b/ERP 2 evaluacion/ClientesForm.cs
@@ -39,7 +39,6 @@ public class ClientesForm : Form
         Text = "Clientes";
         StartPosition = FormStartPosition.CenterParent;
         Size = new Size(1200, 780);
-        MinimumSize = new Size(1024, 680);
 
         UiTheme.ApplyMinimalStyle(this);
 

--- a/ERP 2 evaluacion/InventarioForm.cs
+++ b/ERP 2 evaluacion/InventarioForm.cs
@@ -39,7 +39,6 @@ public class InventarioForm : Form
         Text = "Inventario";
         StartPosition = FormStartPosition.CenterParent;
         Size = new Size(1280, 840);
-        MinimumSize = new Size(1120, 720);
 
         UiTheme.ApplyMinimalStyle(this);
 

--- a/ERP 2 evaluacion/LoginForm.cs
+++ b/ERP 2 evaluacion/LoginForm.cs
@@ -35,7 +35,6 @@ public class LoginForm : Form
         MinimizeBox = true;
         AcceptButton = _btnIngresar;
         Size = new Size(720, 540);
-        MinimumSize = new Size(560, 480);
 
         UiTheme.ApplyMinimalStyle(this);
 
@@ -96,8 +95,6 @@ public class LoginForm : Form
         card.AutoSizeMode = AutoSizeMode.GrowAndShrink;
         card.Anchor = AnchorStyles.None;
         card.Padding = new Padding(40, 40, 40, 32);
-        card.MaximumSize = new Size(560, 0);
-        card.MinimumSize = new Size(520, 0);
         card.Controls.Add(layout);
 
         var root = new TableLayoutPanel

--- a/ERP 2 evaluacion/PerfilesForm.cs
+++ b/ERP 2 evaluacion/PerfilesForm.cs
@@ -26,7 +26,6 @@ public class PerfilesForm : Form
         Text = "Perfiles";
         StartPosition = FormStartPosition.CenterParent;
         Size = new Size(1200, 780);
-        MinimumSize = new Size(1024, 680);
 
         UiTheme.ApplyMinimalStyle(this);
 

--- a/ERP 2 evaluacion/PrincipalForm.cs
+++ b/ERP 2 evaluacion/PrincipalForm.cs
@@ -196,7 +196,6 @@ namespace ERP_2_evaluacion
 
             var summaryCard = UiTheme.CreateCardPanel();
             summaryCard.Padding = new Padding(32, 28, 32, 28);
-            summaryCard.MinimumSize = new Size(280, 0);
 
             var summaryLayout = new TableLayoutPanel
             {

--- a/ERP 2 evaluacion/ProductosForm.cs
+++ b/ERP 2 evaluacion/ProductosForm.cs
@@ -44,7 +44,6 @@ public class ProductosForm : Form
         Text = "Productos";
         StartPosition = FormStartPosition.CenterParent;
         Size = new Size(1280, 840);
-        MinimumSize = new Size(1120, 720);
 
         UiTheme.ApplyMinimalStyle(this);
 

--- a/ERP 2 evaluacion/RegistroForm.cs
+++ b/ERP 2 evaluacion/RegistroForm.cs
@@ -55,7 +55,6 @@ public class RegistroForm : Form
         AcceptButton = _btnRegistrar;
         CancelButton = _btnCancelar;
         Size = new Size(780, 640);
-        MinimumSize = new Size(640, 560);
 
         UiTheme.ApplyMinimalStyle(this);
 
@@ -70,10 +69,10 @@ public class RegistroForm : Form
 
         _dtpUltimoIngreso.Margin = new Padding(0, 6, 0, 16);
         _dtpUltimoIngreso.Dock = DockStyle.Fill;
-        _dtpUltimoIngreso.MinimumSize = new Size(280, 36);
+        _dtpUltimoIngreso.MinimumSize = new Size(0, 36);
         _dtpFechaCreacion.Margin = new Padding(0, 6, 0, 16);
         _dtpFechaCreacion.Dock = DockStyle.Fill;
-        _dtpFechaCreacion.MinimumSize = new Size(280, 36);
+        _dtpFechaCreacion.MinimumSize = new Size(0, 36);
 
         _btnRegistrar.Click += BtnRegistrar_Click;
 
@@ -127,8 +126,6 @@ public class RegistroForm : Form
         card.AutoSizeMode = AutoSizeMode.GrowAndShrink;
         card.Anchor = AnchorStyles.None;
         card.Padding = new Padding(40, 40, 40, 32);
-        card.MaximumSize = new Size(620, 0);
-        card.MinimumSize = new Size(560, 0);
         card.Controls.Add(layout);
 
         var root = new TableLayoutPanel

--- a/ERP 2 evaluacion/ResponsiveFormHelper.cs
+++ b/ERP 2 evaluacion/ResponsiveFormHelper.cs
@@ -9,8 +9,6 @@ internal static class ResponsiveFormHelper
 {
     private const int DefaultDesignWidth = 1280;
     private const int DefaultDesignHeight = 840;
-    private const int MinimumWidth = 960;
-    private const int MinimumHeight = 640;
 
     public static void Attach(Form form)
     {
@@ -76,27 +74,17 @@ internal static class ResponsiveFormHelper
         var screen = Screen.FromControl(form);
         var working = screen.WorkingArea;
 
-        var horizontalMargin = Math.Max(64, (int)Math.Round(working.Width * 0.04));
-        var verticalMargin = Math.Max(64, (int)Math.Round(working.Height * 0.06));
-        var availableWidth = Math.Max(working.Width - horizontalMargin, MinimumWidth);
-        var availableHeight = Math.Max(working.Height - verticalMargin, MinimumHeight);
+        var horizontalMargin = Math.Max(48, (int)Math.Round(working.Width * 0.04));
+        var verticalMargin = Math.Max(48, (int)Math.Round(working.Height * 0.06));
+        var availableWidth = Math.Max(working.Width - horizontalMargin, 0);
+        var availableHeight = Math.Max(working.Height - verticalMargin, 0);
 
-        float scale = Math.Min(availableWidth / (float)designSize.Width, availableHeight / (float)designSize.Height);
-        if (float.IsNaN(scale) || scale <= 0)
-        {
-            scale = 1f;
-        }
-
-        scale = Math.Clamp(scale, 0.85f, 1.15f);
-
-        var targetWidth = (int)Math.Round(designSize.Width * scale);
-        var targetHeight = (int)Math.Round(designSize.Height * scale);
-
-        targetWidth = Math.Clamp(targetWidth, MinimumWidth, availableWidth);
-        targetHeight = Math.Clamp(targetHeight, MinimumHeight, availableHeight);
-
-        form.MaximumSize = new Size(availableWidth, availableHeight);
-        form.MinimumSize = new Size(targetWidth, targetHeight);
+        var targetWidth = availableWidth > 0
+            ? Math.Min(designSize.Width, availableWidth)
+            : designSize.Width;
+        var targetHeight = availableHeight > 0
+            ? Math.Min(designSize.Height, availableHeight)
+            : designSize.Height;
 
         if (form.WindowState != FormWindowState.Maximized)
         {
@@ -104,8 +92,17 @@ internal static class ResponsiveFormHelper
             CenterForm(form, working);
         }
 
-        var padding = (int)Math.Round(Math.Clamp(working.Width * 0.015, 24, 48));
+        form.MaximumSize = Size.Empty;
+        form.MinimumSize = Size.Empty;
+
+        var padding = (int)Math.Round(Math.Clamp(working.Width * 0.015, 20, 48));
         form.Padding = new Padding(padding);
+
+        form.AutoScroll = true;
+        var preferred = form.PreferredSize;
+        var scrollWidth = Math.Max(Math.Max(designSize.Width, preferred.Width), form.AutoScrollMinSize.Width);
+        var scrollHeight = Math.Max(Math.Max(designSize.Height, preferred.Height), form.AutoScrollMinSize.Height);
+        form.AutoScrollMinSize = new Size(scrollWidth, scrollHeight);
     }
 
     private static void CenterForm(Form form, Rectangle working)
@@ -123,13 +120,6 @@ internal static class ResponsiveFormHelper
         }
 
         var working = Screen.FromControl(form).WorkingArea;
-
-        var width = Math.Min(form.Width, working.Width);
-        var height = Math.Min(form.Height, working.Height);
-        if (width != form.Width || height != form.Height)
-        {
-            form.Size = new Size(width, height);
-        }
 
         var x = Math.Min(Math.Max(form.Left, working.Left), working.Right - form.Width);
         var y = Math.Min(Math.Max(form.Top, working.Top), working.Bottom - form.Height);

--- a/ERP 2 evaluacion/SuperUsuarioForm.cs
+++ b/ERP 2 evaluacion/SuperUsuarioForm.cs
@@ -43,7 +43,6 @@ public class SuperUsuarioForm : Form
         AcceptButton = _btnCrear;
         CancelButton = _btnCancelar;
         Size = new Size(780, 640);
-        MinimumSize = new Size(640, 560);
 
         UiTheme.ApplyMinimalStyle(this);
         UiTheme.StyleTextInput(_txtNombreCompleto);
@@ -131,8 +130,6 @@ public class SuperUsuarioForm : Form
         card.AutoSizeMode = AutoSizeMode.GrowAndShrink;
         card.Anchor = AnchorStyles.None;
         card.Padding = new Padding(40, 40, 40, 32);
-        card.MaximumSize = new Size(620, 0);
-        card.MinimumSize = new Size(560, 0);
         card.Controls.Add(layout);
 
         var root = new TableLayoutPanel

--- a/ERP 2 evaluacion/UiTheme.cs
+++ b/ERP 2 evaluacion/UiTheme.cs
@@ -140,7 +140,7 @@ public static class UiTheme
         textBox.BackColor = SurfaceColor;
         textBox.ForeColor = TextColor;
         textBox.Margin = new Padding(0, 6, 0, 16);
-        textBox.MinimumSize = new Size(280, 36);
+        textBox.MinimumSize = new Size(0, 36);
         textBox.Dock = DockStyle.Fill;
     }
 
@@ -152,7 +152,7 @@ public static class UiTheme
         comboBox.Margin = new Padding(0, 6, 0, 16);
         comboBox.DropDownStyle = ComboBoxStyle.DropDownList;
         comboBox.Dock = DockStyle.Fill;
-        comboBox.MinimumSize = new Size(280, 36);
+        comboBox.MinimumSize = new Size(0, 36);
         comboBox.IntegralHeight = false;
     }
 
@@ -207,7 +207,7 @@ public static class UiTheme
         button.Padding = new Padding(20, 10, 20, 10);
         button.Margin = new Padding(8, 0, 0, 0);
         button.AutoSize = true;
-        button.MinimumSize = new Size(160, 44);
+        button.MinimumSize = new Size(0, 44);
         button.Cursor = Cursors.Hand;
         button.UseVisualStyleBackColor = false;
     }

--- a/ERP 2 evaluacion/UsuariosForm.cs
+++ b/ERP 2 evaluacion/UsuariosForm.cs
@@ -32,7 +32,6 @@ public class UsuariosForm : Form
         Text = "Usuarios";
         StartPosition = FormStartPosition.CenterParent;
         Size = new Size(1280, 840);
-        MinimumSize = new Size(1120, 720);
 
         _permitirMostrarContrasenas = permitirMostrarContrasenas;
 

--- a/ERP 2 evaluacion/VentasForm.cs
+++ b/ERP 2 evaluacion/VentasForm.cs
@@ -73,7 +73,6 @@ public class VentasForm : Form
         Text = "Ventas";
         StartPosition = FormStartPosition.CenterParent;
         Size = new Size(1320, 880);
-        MinimumSize = new Size(1180, 760);
 
         UiTheme.ApplyMinimalStyle(this);
 
@@ -155,8 +154,8 @@ public class VentasForm : Form
         control.BorderStyle = BorderStyle.FixedSingle;
         control.Font = UiTheme.BaseFont;
         control.Margin = new Padding(0, 6, 0, 16);
-        control.MinimumSize = new Size(160, 36);
-        control.MaximumSize = new Size(260, 44);
+        control.MinimumSize = new Size(0, 36);
+        control.MaximumSize = Size.Empty;
         control.Dock = DockStyle.Fill;
     }
 


### PR DESCRIPTION
## Summary
- remove fixed minimum sizes from the ERP forms so they can adapt to smaller screens
- update shared theming helpers to keep controls accessible without width constraints
- adjust the responsive helper to enable form scrolling instead of enforcing pixel-based limits

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e30f3321148332a5296576a7e95374