### PR TITLE
Improve hero panel spacing on principal view

### DIFF
--- a/ERP 2 evaluacion/PrincipalForm.cs
+++ b/ERP 2 evaluacion/PrincipalForm.cs
@@ -96,9 +96,9 @@ namespace ERP_2_evaluacion
             var heroPanel = new HeroPanel
             {
                 Dock = DockStyle.Fill,
-                Height = 200,
+                MinimumSize = new Size(0, 240),
                 Margin = new Padding(0, 0, 0, 24),
-                Padding = new Padding(32, 28, 32, 28)
+                Padding = new Padding(32, 36, 32, 40)
             };
 
             var heroLayout = new TableLayoutPanel
@@ -133,7 +133,7 @@ namespace ERP_2_evaluacion
                 AutoSizeMode = AutoSizeMode.GrowAndShrink,
                 FlowDirection = FlowDirection.LeftToRight,
                 WrapContents = false,
-                Margin = new Padding(0, 20, 0, 0)
+                Margin = new Padding(0, 28, 0, 0)
             };
             heroStats.Controls.Add(CrearChipEstadistica("Pantallas activas", _lblHeroTotalPantallas));
             heroStats.Controls.Add(CrearChipEstadistica("Secciones", _lblHeroTotalSecciones));


### PR DESCRIPTION
## Summary
- expand the hero panel padding and minimum height to give the welcome title more breathing room
- increase spacing before the statistics chips so the subtitle no longer crowds the quick access buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3174baa2c83329e09b2182cc50391